### PR TITLE
Avoid false dialyzer warnings by using erlang:nif_error/1

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -91,7 +91,7 @@ init() ->
 
 
 not_loaded(Line) ->
-    exit({not_loaded, [{module, ?MODULE}, {line, Line}]}).
+    erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).
 
 nif_decode(_Data) ->
     ?NOT_LOADED.


### PR DESCRIPTION
Using erlang:nif_error/1 instead of exit/1 for the nif not loaded error handling avoids dialyzer giving off false warnings.

Ref: http://www.erlang.org/doc/man/erlang.html#nif_error-1
