### PR TITLE
Remove hard dependency on proper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ clean:
 	rm -rf .eunit
 	rm -f test/*.beam
 
+distclean: clean
+	rm -rf deps
 
 depends:
 	@if test ! -d ./deps; then \
@@ -25,13 +27,21 @@ etap: test/etap.beam test/util.beam
 	prove test/*.t
 
 
-eunit:
-	$(REBAR) eunit skip_deps=true
+eunit: deps/proper/ebin/proper.beam
+	ERL_FLAGS='-pa deps/proper/ebin' $(REBAR) eunit skip_deps=true
+
+
+deps/proper/ebin/proper.beam: deps/proper
+	cd deps/proper; $(REBAR) compile
+
+deps/proper:
+	mkdir -p deps
+	cd deps; git clone git://github.com/manopapad/proper.git
 
 
 check: build etap eunit
 
-
 %.beam: %.erl
 	erlc -o test/ $<
 
+.PHONY: all clean depends build etap eunit proper check

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,3 @@
-{deps, [
-    {proper, ".*", {git, "https://github.com/manopapad/proper.git", "master"}}
-]}.
-
 {port_specs, [{"priv/jiffy.so", ["c_src/*.c"]}]}.
 
 {port_env, [


### PR DESCRIPTION
Hi,

We are using jiffy now in our Erlang port of the Chef API (https://github.com/opscode/erchef) and we'd like to avoid pulling proper into our builds -- nothing against proper. We would like to minimize what we have to pull down to fetch sources as well as what we end up putting into the OTP releases and this seemed like a fairly small patch.

This also may help avoid confusion since the proper license is different from the jiffy license. Any chance you'd be willing to incorporate this patch?

Best,
- seth

Running "make eunit" will now download proper into deps and ensure it
is on the code path. Projects that depend on jiffy will no longer pick
up a transitive dependency on proper.

When the eunit target is run, proper will be cloned into deps/ if not
already found and compiled (also if not already compiled).

Also includes a few Makefile tweaks:
- Add distclean target
- Add .PHONY for Makefile target hygeine
