### PR TITLE
Removede Werror

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 ]}.
 
 {port_env, [
-    {".*", "CXXFLAGS", "$CXXFLAGS -g -Wall -Werror -O3"},
+    {".*", "CXXFLAGS", "$CXXFLAGS -g -Wall -O3"},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
         "LDFLAGS", "$LDFLAGS -lstdc++"},


### PR DESCRIPTION
Werror should not be enabled when distributing source code. Werror is very helpful when developing code, but different compiler versions could easily break builds.
