### PR TITLE
Add compile option no_native

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -5,6 +5,8 @@
 -export([decode/1, decode/2, encode/1, encode/2]).
 -define(NOT_LOADED, not_loaded(?LINE)).
 
+-compile([no_native]).
+
 -on_load(init/0).
 
 


### PR DESCRIPTION
HiPE doesn't support on_load call. This change makes it possible to apply the native flag to all files in a project that includes jiffy as a dependency.

    ==> jiffy (compile)
    <HiPE (v 3.11)> EXITED with reason {'trans_fun/2',on_load} @hipe_beam_to_icode:1174
    
    =ERROR REPORT==== 15-Jul-2014::22:59:36 ===
    Error in process <0.6593.0> with exit value: {{badmatch,{'EXIT',{{hipe_beam_to_icode,1174,{'trans_fun/2',on_load}},[{hipe_beam_to_icode,trans_fun,2,[{file,"hipe_beam_to_icode.erl"},{line,1174}]},{hipe_beam_to_icode,trans_fun,2,[{file,"hipe_beam_to_icode.erl"},{line,277}]},{hipe_beam_to_icode...
    
    Compiling /Users/lpgauth/Git/rtb-gateway/deps/jiffy/src/jiffy.erl failed:
    /Users/lpgauth/Git/rtb-gateway/deps/jiffy/src/jiffy.erl:none: internal error in native_compile;
    crash reason: {badmatch,
        {'EXIT',
            {{hipe_beam_to_icode,1174,{'trans_fun/2',on_load}},
             [{hipe_beam_to_icode,trans_fun,2,
                  [{file,"hipe_beam_to_icode.erl"},{line,1174}]},
              {hipe_beam_to_icode,trans_fun,2,
                  [{file,"hipe_beam_to_icode.erl"},{line,277}]},
              {hipe_beam_to_icode,trans_mfa_code,5,
                  [{file,"hipe_beam_to_icode.erl"},{line,148}]},
              {hipe_beam_to_icode,trans_beam_function_chunk,2,
                  [{file,"hipe_beam_to_icode.erl"},{line,133}]},
              {hipe_beam_to_icode,'-module/2-lc$^1/1-1-',2,
                  [{file,"hipe_beam_to_icode.erl"},{line,129}]},
              {hipe_beam_to_icode,'-module/2-lc$^1/1-1-',2,
                  [{file,"hipe_beam_to_icode.erl"},{line,129}]},
              {hipe,get_beam_icode,4,[{file,"hipe.erl"},{line,597}]},
              {hipe,'-run_compiler_1/3-fun-0-',4,
                  [{file,"hipe.erl"},{line,668}]}]}}}
    
      in function  hipe:get_beam_icode/4 (hipe.erl, line 596)
      in call from hipe:'-run_compiler_1/3-fun-0-'/4 (hipe.erl, line 668)
    ERROR: compile failed while processing /Users/lpgauth/Git/rtb-gateway/deps/jiffy: rebar_abort