### PR TITLE
Add OsX ppc compilation support.

### DIFF
--- a/c_src/double-conversion/utils.h
+++ b/c_src/double-conversion/utils.h
@@ -55,7 +55,8 @@
 #if defined(_M_X64) || defined(__x86_64__) || \
     defined(__ARMEL__) || defined(__avr32__) || \
     defined(__hppa__) || defined(__ia64__) || \
-    defined(__mips__) || defined(__powerpc__) || \
+    defined(__mips__) || \
+    defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
     defined(__SH4__) || defined(__alpha__) || \
     defined(_MIPS_ARCH_MIPS32R2)


### PR DESCRIPTION
From upstream (https://github.com/floitsch/double-conversion/commit/24c2fa1245ac0cc4b02b3b3f582256e0532551d4)

Now compiles without error on a G4 processor.