### PR TITLE
Changed pos to unsigned int to prevent warning from happening.

### DIFF
--- a/c_src/double-conversion/bignum.cc
+++ b/c_src/double-conversion/bignum.cc
@@ -103,7 +103,7 @@ void Bignum::AssignDecimalString(Vector<const char> value) {
   const int kMaxUint64DecimalDigits = 19;
   Zero();
   int length = value.length();
-  int pos = 0;
+  unsigned int pos = 0;
   // Let's just say that each digit needs 4 bits.
   while (length >= kMaxUint64DecimalDigits) {
     uint64_t digits = ReadUInt64(value, pos, kMaxUint64DecimalDigits);


### PR DESCRIPTION
Set pos to be unsigned to prevent warning from GCC 5.1.0. Fixes the problem instead of silencing the warning.