### PR TITLE
Add -fwrapv to CXXFLAGS

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
         "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall -Werror -O3 -fno-strict-aliasing"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
-        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall -Werror -O3"},
+        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall -Werror -O3 -fwrapv"},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
         "LDFLAGS", "$LDFLAGS -lstdc++"},


### PR DESCRIPTION
This fixes a following overflow error when compiling with GCC 5:

    Compiling bignum.cc
    bignum.cc: In member function ‘void double_conversion::Bignum::AssignDecimalString(double_conversion::Vector<const char>)’:
    bignum.cc:101:6: error: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Werror=strict-overflow]
     void Bignum::AssignDecimalString(Vector<const char> value) {
          ^
    cc1plus: all warnings being treated as errors

From man gcc(1):
> -fwrapv
>   This option instructs the compiler to assume that signed arithmetic
>   overflow of addition, subtraction and multiplication wraps around
>   using twos-complement representation.

Fixes #97.