### PR TITLE
bignum.cc: fix -Werror=strict-overflow issue

### DIFF
--- a/c_src/double-conversion/bignum.cc
+++ b/c_src/double-conversion/bignum.cc
@@ -104,7 +104,7 @@ void Bignum::AssignDecimalString(Vector<const char> value) {
   const int kMaxUint64DecimalDigits = 19;
   Zero();
   int length = value.length();
-  int pos = 0;
+  unsigned int pos = 0;
   // Let's just say that each digit needs 4 bits.
   while (length >= kMaxUint64DecimalDigits) {
     uint64_t digits = ReadUInt64(value, pos, kMaxUint64DecimalDigits);


### PR DESCRIPTION
Fixes compilation error with GCC 5.x:

c_src/double-conversion/bignum.cc:102:6: error: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Werror=strict-overflow]
 void Bignum::AssignDecimalString(Vector<const char> value) {
      ^
cc1plus: all warnings being treated as errors