### PR TITLE
rebar.config: set CFLAGS/CXXFLAGS/LDFLAGS on Hurd

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,12 +7,12 @@
 ]}.
 
 {port_env, [
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
+    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
         "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall -Werror -O3 -fno-strict-aliasing"},
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
+    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
         "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall -Werror -O3"},
 
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin)",
+    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
         "LDFLAGS", "$LDFLAGS -lstdc++"},
 
     %% OS X Leopard flags for 64-bit


### PR DESCRIPTION
Use the common `CFLAGS`/`CXXFLAGS`/`LDFLAGS` used on Linux/FreeBSD/etc also on GNU/Hurd.