### PR TITLE
Fix jiffy:encode Dialyzer spec.

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -77,12 +77,12 @@ decode(Data, Opts) when is_list(Data) ->
     decode(iolist_to_binary(Data), Opts).
 
 
--spec encode(json_value()) -> iolist().
+-spec encode(json_value()) -> iodata().
 encode(Data) ->
     encode(Data, []).
 
 
--spec encode(json_value(), encode_options()) -> iolist().
+-spec encode(json_value(), encode_options()) -> iodata().
 encode(Data, Options) ->
     ForceUTF8 = lists:member(force_utf8, Options),
     case nif_encode_init(Data, Options) of


### PR DESCRIPTION
The function returns a binary, which is not an iolist(). I have changed the spec to iodata() (iodata() = binary() | iolist()), but maybe the spec can be changed to just binary() directly; is there a case when the encode function can correctly finish and return something other than a binary?