### PR TITLE
recognize bytes_per_red option, reject 0 value

### DIFF
--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -25,6 +25,7 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_force_utf8 = make_atom(env, "force_utf8");
     st->atom_iter = make_atom(env, "iter");
     st->atom_bytes_per_iter = make_atom(env, "bytes_per_iter");
+    st->atom_bytes_per_red = make_atom(env, "bytes_per_red");
     st->atom_return_maps = make_atom(env, "return_maps");
     st->atom_return_trailer = make_atom(env, "return_trailer");
     st->atom_has_trailer = make_atom(env, "has_trailer");

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -28,6 +28,7 @@ typedef struct {
     ERL_NIF_TERM    atom_force_utf8;
     ERL_NIF_TERM    atom_iter;
     ERL_NIF_TERM    atom_bytes_per_iter;
+    ERL_NIF_TERM    atom_bytes_per_red;
     ERL_NIF_TERM    atom_return_maps;
     ERL_NIF_TERM    atom_return_trailer;
     ERL_NIF_TERM    atom_has_trailer;

--- a/c_src/util.c
+++ b/c_src/util.c
@@ -54,7 +54,7 @@ get_bytes_per_iter(ErlNifEnv* env, ERL_NIF_TERM val, size_t* bpi)
         return 0;
     }
 
-    if(!enif_get_uint(env, tuple[1], &bytes) || !bytes) {
+    if(!enif_get_uint(env, tuple[1], &bytes)) {
         return 0;
     }
 
@@ -84,7 +84,7 @@ get_bytes_per_red(ErlNifEnv* env, ERL_NIF_TERM val, size_t* bpi)
         return 0;
     }
 
-    if(!enif_get_uint(env, tuple[1], &bytes) || !bytes) {
+    if(!enif_get_uint(env, tuple[1], &bytes)) {
         return 0;
     }
 
@@ -124,6 +124,10 @@ get_null_term(ErlNifEnv* env, ERL_NIF_TERM val, ERL_NIF_TERM *null_term)
 int
 should_yield(ErlNifEnv* env, size_t* used, size_t bytes_per_red)
 {
+    if (!bytes_per_red) {
+        return 0;
+    }
+
 #if(ERL_NIF_MAJOR_VERSION >= 2 && ERL_NIF_MINOR_VERSION >= 4)
 
     if(((*used) / bytes_per_red) >= 20) {

--- a/c_src/util.c
+++ b/c_src/util.c
@@ -54,7 +54,7 @@ get_bytes_per_iter(ErlNifEnv* env, ERL_NIF_TERM val, size_t* bpi)
         return 0;
     }
 
-    if(!enif_get_uint(env, tuple[1], &bytes)) {
+    if(!enif_get_uint(env, tuple[1], &bytes) || !bytes) {
         return 0;
     }
 
@@ -80,11 +80,11 @@ get_bytes_per_red(ErlNifEnv* env, ERL_NIF_TERM val, size_t* bpi)
         return 0;
     }
 
-    if(enif_compare(tuple[0], st->atom_bytes_per_iter) != 0) {
+    if(enif_compare(tuple[0], st->atom_bytes_per_red) != 0) {
         return 0;
     }
 
-    if(!enif_get_uint(env, tuple[1], &bytes)) {
+    if(!enif_get_uint(env, tuple[1], &bytes) || !bytes) {
         return 0;
     }
 


### PR DESCRIPTION
`bytes_per_red` option is currently not recognized.. also, 0 value causes an issue here: https://github.com/davisp/jiffy/blob/66594cf6f4dc7ecdd17f742d103e55437edea972/c_src/util.c#L129
