### PR TITLE
Updated jiffy.app.src with metadata for hexer app to be uploaded on hex.pm

### DIFF
--- a/src/jiffy.app.src
+++ b/src/jiffy.app.src
@@ -2,5 +2,9 @@
     {description, "JSON Decoder/Encoder."},
     {vsn, git},
     {registered, []},
-    {applications, [kernel, stdlib]}
+    {applications, [kernel, stdlib]},
+    {registered, []},
+    {maintainers, ["davisp"]},
+    {licenses, ["ISC"]},
+    {links, [{"Github", "https://github.com/davisp/jiffy"}]}
 ]}.


### PR DESCRIPTION
Hello Paul. Please, could you add this metadata to jiffy? it is necessary to run [hexer](https://github.com/inaka/hexer) for upload the project to hex.pm package manager.
Thanks.