### PR TITLE
Fixed wrong jiffy:decode/2 spec

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -61,7 +61,7 @@ decode(Data) ->
     decode(Data, []).
 
 
--spec decode(iolist() | binary(), decode_options()) -> json_value().
+-spec decode(iolist() | binary(), decode_options()) -> jiffy_decode_result().
 decode(Data, Opts) when is_binary(Data), is_list(Opts) ->
     case nif_decode_init(Data, Opts) of
         {error, _} = Error ->


### PR DESCRIPTION
In this code

```erlang
case jiffy:decode(Data, [return_trailer, return_maps]) of
    {has_trailer,Object, Rest} -> 
        ...
    ObjectDecoded when is_map(ObjectDecoded) -> 
        ...
end.
```

call ```rebar3 dialyzer```

You will get

```
The pattern {'has_trailer', Object, Rest} can never match the type atom() | binary() | [atom() | binary() | [any()] | number() | {[{atom() | binary(),_}]} | #{}] | number() | {[{atom() | binary(),atom() | binary() | [any()] | number() | {[{atom() | binary(),_}]} | #{}}]} | #{}
```