### PR TITLE
Add `use_nil` to `encode_option`

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -46,6 +46,7 @@
 -type encode_option() :: uescape
                         | pretty
                         | force_utf8
+                        | use_nil
                         | escape_forward_slashes
                         | {bytes_per_iter, non_neg_integer()}
                         | {bytes_per_red, non_neg_integer()}.


### PR DESCRIPTION
A call to `jiffy:encode(Term, [use_nil]).` will currently cause dialyzer
to issue a warning because `use_nil` is not included in `encode_option`.
This appears to just be an omission.
