### PR TITLE
Fetch dependencies rather from hex.pm instead from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 .jiffy.dev
 *.app
 *.beam
+*.d
 *.o
 *.so
+_build
 deps
 erln8.config
 hexer.config

--- a/rebar.config
+++ b/rebar.config
@@ -33,13 +33,5 @@
 ]}.
 
 {eunit_opts, [
-    verbose,
-    {report, {
-        eunit_surefire, [{dir,"."}]
-    }}
+    verbose
 ]}.
-
-{plugins, [
-    rebar_gdb_plugin
-]}.
-

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -7,31 +7,56 @@
 %
 % This script is based on the example provided with Rebar.
 
-ErlOpts = [{d, 'JIFFY_DEV'}],
+IsRebar3 = erlang:function_exported(rebar3, main, 1),
 
-Proper = [
-    {proper, ".*", {git, "git://github.com/manopapad/proper.git", "master"}}
+PropErUrl = "git://github.com/manopapad/proper.git",
+PortCompilerUrl = "git@github.com:blt/port_compiler.git",
+
+
+IsDevEnv = begin
+    ConfigPath = filename:dirname(SCRIPT),
+    DevMarker = filename:join([ConfigPath, ".jiffy.dev"]),
+    filelib:is_file(DevMarker)
+end.
+
+Deps = if not IsDevEnv -> []; true ->
+    [{proper, ".*", {git, PropErUrl, {branch, "master"}}}]
+end,
+
+ErlOpts = if not IsDevEnv -> []; true ->
+    [{d, 'JIFFY_DEV'}]
+end,
+
+Plugins = case IsRebar3 of
+    true -> [{pc, {git, PortCompilerUrl, {branch, "master"}}}];
+    false -> [rebar_gdb_plugin]
+end,
+
+ProviderHooks = if not IsRebar3 -> []; true ->
+    [{pre, [
+        {compile, {pc, compile}},
+        {clean, {pc, clean}}
+    ]}]
+end,
+
+OptsToAdd = [
+    {deps, Deps},
+    {erl_opts, ErlOpts},
+    {plugins, Plugins},
+    {provider_hooks, ProviderHooks}
 ],
 
-ConfigPath = filename:dirname(SCRIPT),
-DevMarker = filename:join([ConfigPath, ".jiffy.dev"]),
+AddOpt = fun(Name, Value, Config) when is_list(Value) ->
+    case lists:keyfind(Name, 1, Config) of
+        {Name, CurrVal} when is_list(CurrVal) ->
+            lists:keyreplace(Name, 1, Config, {Name, CurrVal ++ Value});
+        false ->
+            Config ++ [{Name, Value}];
+        _ ->
+            Config
+    end
+end,
 
-case filelib:is_file(DevMarker) of
-    true ->
-        % Don't override existing dependencies
-        Config0 = case lists:keyfind(deps, 1, CONFIG) of
-            false ->
-                CONFIG ++ [{deps, Proper}];
-            {deps, DepsList} ->
-                lists:keyreplace(deps, 1, CONFIG, {deps, DepsList ++ Proper})
-        end,
-        Config1 = case lists:keyfind(erl_opts, 1, Config0) of
-            false ->
-                Config0 ++ [{erl_opts, ErlOpts}];
-            {erl_opts, Opts} ->
-                NewOpts = {erl_opts, Opts ++ ErlOpts},
-                lists:keyreplace(erl_opts, 1, Config0, NewOpts)
-        end;
-    false ->
-        CONFIG
-end.
+lists:foldl(fun({Name, Value}, CfgAcc) ->
+    AddOpt(Name, Value, CfgAcc)
+end, CONFIG, OptsToAdd).

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -10,7 +10,6 @@
 IsRebar3 = erlang:function_exported(rebar3, main, 1),
 
 PropErUrl = "git://github.com/manopapad/proper.git",
-PortCompilerUrl = "git@github.com:blt/port_compiler.git",
 
 
 IsDevEnv = begin
@@ -28,7 +27,7 @@ ErlOpts = if not IsDevEnv -> []; true ->
 end,
 
 Plugins = case IsRebar3 of
-    true -> [{pc, {git, PortCompilerUrl, {branch, "master"}}}];
+    true -> [pc];
     false -> [rebar_gdb_plugin]
 end,
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -19,7 +19,10 @@ IsDevEnv = begin
 end.
 
 Deps = if not IsDevEnv -> []; true ->
-    [{proper, ".*", {git, PropErUrl, {branch, "master"}}}]
+    case IsRebar3 of
+        true -> [proper];
+        false -> [{proper, ".*", {git, PropErUrl, {branch, "master"}}}]
+    end
 end,
 
 ErlOpts = if not IsDevEnv -> []; true ->

--- a/test/jiffy_10_short_double_tests.erl
+++ b/test/jiffy_10_short_double_tests.erl
@@ -8,7 +8,14 @@
 -include("jiffy_util.hrl").
 
 
-filename() -> "../test/cases/short-doubles.txt".
+filename() ->
+    {ok, Cwd} = file:get_cwd(),
+    case filename:basename(Cwd) of
+        ".eunit" ->
+            "../test/cases/short-doubles.txt";
+        _ ->
+            "test/cases/short-doubles.txt"
+    end.
 
 
 short_double_test_() ->


### PR DESCRIPTION
When building with `rebar3` I would suggest to fetch `pc` and `proper` rather from `hex.pm` than fetching sources directly from GitHub. This should improve and hardening the build process. For example we had a lot of `dependency is not available` errors on our CI server recently which resulted in build errors:

```
...
build   12-Sep-2016 15:04:52    ===> Fetching pc ({git,"git@github.com:blt/port_compiler.git",
build   12-Sep-2016 15:04:52                           {branch,"master"}})
build   12-Sep-2016 15:04:53    ===> Plugin {pc,{git,"git@github.com:blt/port_compiler.git",
build   12-Sep-2016 15:04:53                         {branch,"master"}}} not available. It will not be used.
...
build   12-Sep-2016 15:05:21    ===> Compiling jiffy
build   12-Sep-2016 15:05:21    ===> Unable to run pre hooks for 'compile', command 'compile' in namespace 'pc' not found.
error   12-Sep-2016 15:05:21    make: *** [compile] Error 1
```

After applying this changes:

```
build   12-Sep-2016 15:26:10    ===> Fetching jiffy ({git,"https://github.com/synlay/jiffy.git",
build   12-Sep-2016 15:26:10                              {ref,"8f4a18c1f63cf45b502155e93097ecbdddbec798"}})
build   12-Sep-2016 15:26:14    ===> Fetching pc ({pkg,<<"pc">>,<<"1.4.0">>})
build   12-Sep-2016 15:26:14    ===> Downloaded package, caching at /root/.cache/rebar3/hex/default/packages/pc-1.4.0.tar
build   12-Sep-2016 15:26:14    ===> Compiling pc
```

Including dependencies this way will include the latest version from `hex.pm`. Maybe you should consider including a `rebar.lock`. Some additional infos can be found [here](http://www.rebar3.org/docs/dependencies#package-manager-dependencies).
