### PR TITLE
Add preencoded JSON support. 

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -642,6 +642,36 @@ enc_object_element(Encoder* e, int first, ERL_NIF_TERM curr, ERL_NIF_TERM* stack
 }
 
 ERL_NIF_TERM
+enc_array_element(Encoder* e, int first, ERL_NIF_TERM curr, ERL_NIF_TERM* stackp)
+{
+    ErlNifEnv* env = e->env;
+    ERL_NIF_TERM stack = *stackp;
+    ERL_NIF_TERM item;
+
+    if(first && !enc_start_array(e)) {
+        return enc_error(e, "internal_error");
+    }
+    if(enif_is_empty_list(env, curr)) {
+        if(!enc_end_array(e)) {
+            return enc_error(e, "internal_error");
+        }
+        return 0;
+    }
+    if(!first && !enc_comma(e)) {
+        return enc_error(e, "internal_error");
+    }
+    if(!enif_get_list_cell(env, curr, &item, &curr)) {
+        return enc_error(e, "internal_error");
+    }
+    stack = enif_make_list_cell(env, curr, stack);
+    stack = enif_make_list_cell(env, e->atoms->ref_array, stack);
+    stack = enif_make_list_cell(env, item, stack);
+    *stackp = stack;
+    return 0;
+}
+
+
+ERL_NIF_TERM
 encode_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     jiffy_st* st = (jiffy_st*) enif_priv_data(env);
@@ -762,24 +792,8 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 ret = enc_error(e, "internal_error");
                 goto done;
             }
-            if(enif_is_empty_list(env, curr)) {
-                if(!enc_end_array(e)) {
-                    ret = enc_error(e, "internal_error");
-                    goto done;
-                }
-                continue;
-            }
-            if(!enc_comma(e)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            if(!enif_get_list_cell(env, curr, &item, &curr)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            stack = enif_make_list_cell(env, curr, stack);
-            stack = enif_make_list_cell(env, e->atoms->ref_array, stack);
-            stack = enif_make_list_cell(env, item, stack);
+            ret = enc_array_element(e, 0, curr, &stack);
+            if(ret) { goto done; }
         } else if(enif_compare(curr, e->atoms->atom_null) == 0) {
             if(!enc_literal(e, "null", 4)) {
                 ret = enc_error(e, "null");
@@ -854,24 +868,8 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
             stack = enif_make_list_cell(env, curr, stack);
 #endif
         } else if(enif_is_list(env, curr)) {
-            if(!enc_start_array(e)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            if(enif_is_empty_list(env, curr)) {
-                if(!enc_end_array(e)) {
-                    ret = enc_error(e, "internal_error");
-                    goto done;
-                }
-                continue;
-            }
-            if(!enif_get_list_cell(env, curr, &item, &curr)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            stack = enif_make_list_cell(env, curr, stack);
-            stack = enif_make_list_cell(env, e->atoms->ref_array, stack);
-            stack = enif_make_list_cell(env, item, stack);
+            ret = enc_array_element(e, 1, curr, &stack);
+            if(ret) { goto done; }
         } else {
             if(!enc_unknown(e, curr)) {
                 ret = enc_error(e, "internal_error");

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -599,6 +599,49 @@ enc_map_to_ejson(ErlNifEnv* env, ERL_NIF_TERM map, ERL_NIF_TERM* out)
 #endif
 
 ERL_NIF_TERM
+enc_object_element(Encoder* e, int first, ERL_NIF_TERM curr, ERL_NIF_TERM* stackp)
+{
+    ErlNifEnv* env = e->env;
+    ERL_NIF_TERM stack = *stackp;
+    ERL_NIF_TERM item;
+    const ERL_NIF_TERM* tuple;
+    int arity;
+
+    if(first && !enc_start_object(e)) {
+        return enc_error(e, "internal_error");
+    }
+    if(enif_is_empty_list(env, curr)) {
+        if(!enc_end_object(e)) {
+            return enc_error(e, "internal_error");
+        }
+        return 0;
+    }
+    if(!enif_get_list_cell(env, curr, &item, &curr)) {
+        return enc_error(e, "internal_error");
+    }
+    if(!enif_get_tuple(env, item, &arity, &tuple)) {
+        return enc_obj_error(e, "invalid_object_member", item);
+    }
+    if(arity != 2) {
+        return enc_obj_error(e, "invalid_object_member_arity", item);
+    }
+    if(!first && !enc_comma(e)) {
+        return enc_error(e, "internal_error");
+    }
+    if(!enc_string(e, tuple[0])) {
+        return enc_obj_error(e, "invalid_object_member_key", tuple[0]);
+    }
+    if(!enc_colon(e)) {
+        return enc_error(e, "internal_error");
+    }
+    stack = enif_make_list_cell(env, curr, stack);
+    stack = enif_make_list_cell(env, e->atoms->ref_object, stack);
+    stack = enif_make_list_cell(env, tuple[1], stack);
+    *stackp = stack;
+    return 0;
+}
+
+ERL_NIF_TERM
 encode_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     jiffy_st* st = (jiffy_st*) enif_priv_data(env);
@@ -712,40 +755,8 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 ret = enc_error(e, "internal_error");
                 goto done;
             }
-            if(enif_is_empty_list(env, curr)) {
-                if(!enc_end_object(e)) {
-                    ret = enc_error(e, "internal_error");
-                    goto done;
-                }
-                continue;
-            }
-            if(!enif_get_list_cell(env, curr, &item, &curr)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            if(!enif_get_tuple(env, item, &arity, &tuple)) {
-                ret = enc_obj_error(e, "invalid_object_member", item);
-                goto done;
-            }
-            if(arity != 2) {
-                ret = enc_obj_error(e, "invalid_object_member_arity", item);
-                goto done;
-            }
-            if(!enc_comma(e)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            if(!enc_string(e, tuple[0])) {
-                ret = enc_obj_error(e, "invalid_object_member_key", tuple[0]);
-                goto done;
-            }
-            if(!enc_colon(e)) {
-                ret = enc_error(e, "internal_error");
-                goto done;
-            }
-            stack = enif_make_list_cell(env, curr, stack);
-            stack = enif_make_list_cell(env, e->atoms->ref_object, stack);
-            stack = enif_make_list_cell(env, tuple[1], stack);
+            ret = enc_object_element(e, 0, curr, &stack);
+            if(ret) { goto done; }
         } else if(enif_is_identical(curr, e->atoms->ref_array)) {
             if(!enif_get_list_cell(env, stack, &curr, &stack)) {
                 ret = enc_error(e, "internal_error");
@@ -815,40 +826,8 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                     ret = enc_obj_error(e, "invalid_object", curr);
                     goto done;
                 }
-                if(!enc_start_object(e)) {
-                    ret = enc_error(e, "internal_error");
-                    goto done;
-                }
-                if(enif_is_empty_list(env, tuple[0])) {
-                    if(!enc_end_object(e)) {
-                        ret = enc_error(e, "internal_error");
-                        goto done;
-                    }
-                    continue;
-                }
-                if(!enif_get_list_cell(env, tuple[0], &item, &curr)) {
-                    ret = enc_error(e, "internal_error");
-                    goto done;
-                }
-                if(!enif_get_tuple(env, item, &arity, &tuple)) {
-                    ret = enc_obj_error(e, "invalid_object_member", item);
-                    goto done;
-                }
-                if(arity != 2) {
-                    ret = enc_obj_error(e, "invalid_object_member_arity", item);
-                    goto done;
-                }
-                if(!enc_string(e, tuple[0])) {
-                    ret = enc_obj_error(e, "invalid_object_member_key", tuple[0]);
-                    goto done;
-                }
-                if(!enc_colon(e)) {
-                    ret = enc_error(e, "internal_error");
-                    goto done;
-                }
-                stack = enif_make_list_cell(env, curr, stack);
-                stack = enif_make_list_cell(env, e->atoms->ref_object, stack);
-                stack = enif_make_list_cell(env, tuple[1], stack);
+                ret = enc_object_element(e, 1, tuple[0], &stack);
+                if (ret) { goto done; }
             } else if(arity == 2) {
                 if(enif_compare(tuple[0], e->atoms->atom_json) != 0) {
                     ret = enc_obj_error(e, "invalid_ejson", curr);

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -16,6 +16,7 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_null = make_atom(env, "null");
     st->atom_true = make_atom(env, "true");
     st->atom_false = make_atom(env, "false");
+    st->atom_json = make_atom(env, "json");
     st->atom_bignum = make_atom(env, "bignum");
     st->atom_bignum_e = make_atom(env, "bignum_e");
     st->atom_bigdbl = make_atom(env, "bigdbl");

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -17,6 +17,8 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_true = make_atom(env, "true");
     st->atom_false = make_atom(env, "false");
     st->atom_json = make_atom(env, "json");
+    st->atom_partial_object = make_atom(env, "$partial_object$");
+    st->atom_partial_array = make_atom(env, "$partial_array$");
     st->atom_bignum = make_atom(env, "bignum");
     st->atom_bignum_e = make_atom(env, "bignum_e");
     st->atom_bigdbl = make_atom(env, "bigdbl");

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -19,6 +19,7 @@ typedef struct {
     ERL_NIF_TERM    atom_null;
     ERL_NIF_TERM    atom_true;
     ERL_NIF_TERM    atom_false;
+    ERL_NIF_TERM    atom_json;
     ERL_NIF_TERM    atom_bignum;
     ERL_NIF_TERM    atom_bignum_e;
     ERL_NIF_TERM    atom_bigdbl;

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -20,6 +20,8 @@ typedef struct {
     ERL_NIF_TERM    atom_true;
     ERL_NIF_TERM    atom_false;
     ERL_NIF_TERM    atom_json;
+    ERL_NIF_TERM    atom_partial_object;
+    ERL_NIF_TERM    atom_partial_array;
     ERL_NIF_TERM    atom_bignum;
     ERL_NIF_TERM    atom_bignum_e;
     ERL_NIF_TERM    atom_bigdbl;

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -2,7 +2,7 @@
 % See the LICENSE file for more information.
 
 -module(jiffy).
--export([decode/1, decode/2, encode/1, encode/2]).
+-export([decode/1, decode/2, encode/1, encode/2, partial_encode/2]).
 -define(NOT_LOADED, not_loaded(?LINE)).
 
 -compile([no_native]).
@@ -105,6 +105,16 @@ encode(Data, Options) ->
         IOData ->
             IOData
     end.
+
+
+-spec partial_encode(json_array(), encode_options()) -> {'$partial_array$', binary()};
+                    (json_object(), encode_options()) -> {'$partial_object$', binary()}.
+partial_encode(Data, Options) when is_list(Data) ->
+    Json = iolist_to_binary(encode(Data, Options)),
+    {'$partial_array$', binary_part(Json, 1, byte_size(Json) - 2)};
+partial_encode(Data, Options) when is_tuple(Data) ->
+    Json = iolist_to_binary(encode(Data, Options)),
+    {'$partial_object$', binary_part(Json, 1, byte_size(Json) - 2)}.
 
 
 finish_decode({bignum, Value}) ->

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -16,7 +16,8 @@
                     | json_string()
                     | json_number()
                     | json_object()
-                    | json_array().
+                    | json_array()
+                    | json_preencoded().
 
 -type json_array()  :: [json_value()].
 -type json_string() :: atom() | binary().
@@ -32,6 +33,8 @@
                         | #{json_string() => json_value()}.
 
 -endif.
+
+-type json_preencoded() :: {json, Json::binary()}.
 
 -type jiffy_decode_result() :: json_value()
                         | {has_trailer, json_value(), binary()}.

--- a/test/jiffy_16_preencode_tests.erl
+++ b/test/jiffy_16_preencode_tests.erl
@@ -1,0 +1,53 @@
+-module(jiffy_16_preencode_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+-include("jiffy_util.hrl").
+
+
+preencode_success_test_() ->
+    [gen(ok, Case) || Case <- cases(ok)].
+
+
+preencode_failure_test_() ->
+    [gen(error, Case) || Case <- cases(error)].
+
+
+gen(ok, {E1, J, E2}) ->
+    {msg("~p", [E1]), [
+        {"Encode", ?_assertEqual(J, enc(E1))},
+        {"Decode", ?_assertEqual(E2, dec(J))}
+    ]};
+
+gen(error, E) ->
+    {msg("Error: ~p", [E]), [
+        ?_assertThrow({error, _}, enc(E))
+    ]}.
+
+
+cases(ok) ->
+    TopTests =
+        lists:map(
+          fun (EJSON) ->
+                  JSON = enc(EJSON),
+                  {{json, JSON}, JSON, EJSON}
+          end, [ 123
+               , <<"hello world">>
+               , true
+               , false
+               , {[ {<<"a">>, <<"apple">>}, {<<"b">>, <<"banana">>} ]}
+               ]),
+    EJSON = [ 1, <<"a">> ],
+    JSON = enc(EJSON),
+    BuriedTests =
+        [ { [ {json, JSON} ], <<"[[1,\"a\"]]">>, [ EJSON ]}
+        , { [ 1, {json, JSON}, 3 ], <<"[1,[1,\"a\"],3]">>, [ 1, EJSON, 3 ]}
+        , { [ {json, JSON}, {json, JSON} ], <<"[[1,\"a\"],[1,\"a\"]]">>, [ EJSON, EJSON ]}
+        , { {[ {<<"a">>, {json, JSON}} ]}, <<"{\"a\":[1,\"a\"]}">>, {[ {<<"a">>, EJSON} ]}}
+        ],
+    TopTests ++ BuriedTests;
+
+cases(error) ->
+    [ {json, true}
+    , {json, "true"}
+    ].


### PR DESCRIPTION
Issue #128 requested support for preencoded raw JSON in jiffy:encode. Since this is something that would be useful for me too I wrote some code to implement it. Is this something that you are interested in supporting in mainline jiffy? If so, let me know and I will continue with adding documentation to get this pull request to a mergeable state. As it is, I have used the syntax suggested in #128, namely `{json, JSON}` is accepted anywhere a `json_value()` is.

I'm also considering adding support for partially-encoded objects and lists (where more fields could later be added to the object or more elements to the list).