### PR TITLE
Pre-encoded JSON support, take 2

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -781,8 +781,11 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
             }
         } else if(enif_get_tuple(env, curr, &arity, &tuple)) {
             if(arity != 1) {
-                ret = enc_obj_error(e, "invalid_ejson", curr);
-                goto done;
+                if(!enc_unknown(e, curr)) {
+                    ret = enc_error(e, "internal_error");
+                    goto done;
+                }
+                continue;
             }
             if(!enif_is_list(env, tuple[0])) {
                 ret = enc_obj_error(e, "invalid_object", curr);

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -16,6 +16,8 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_null = make_atom(env, "null");
     st->atom_true = make_atom(env, "true");
     st->atom_false = make_atom(env, "false");
+    st->atom_partial_object = make_atom(env, "$partial_object$");
+    st->atom_partial_array = make_atom(env, "$partial_array$");
     st->atom_bignum = make_atom(env, "bignum");
     st->atom_bignum_e = make_atom(env, "bignum_e");
     st->atom_bigdbl = make_atom(env, "bigdbl");

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -19,6 +19,8 @@ typedef struct {
     ERL_NIF_TERM    atom_null;
     ERL_NIF_TERM    atom_true;
     ERL_NIF_TERM    atom_false;
+    ERL_NIF_TERM    atom_partial_object;
+    ERL_NIF_TERM    atom_partial_array;
     ERL_NIF_TERM    atom_bignum;
     ERL_NIF_TERM    atom_bignum_e;
     ERL_NIF_TERM    atom_bigdbl;

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -160,6 +160,8 @@ finish_encode([<<_/binary>>=B | Rest], Acc) ->
 finish_encode([Val | Rest], Acc) when is_integer(Val) ->
     Bin = list_to_binary(integer_to_list(Val)),
     finish_encode(Rest, [Bin | Acc]);
+finish_encode([{json, Json} | Rest], Acc) ->
+    finish_encode(Rest, [Json | Acc]);
 finish_encode([InvalidEjson | _], _) ->
     throw({error, {invalid_ejson, InvalidEjson}});
 finish_encode(_, _) ->

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -16,7 +16,8 @@
                     | json_string()
                     | json_number()
                     | json_object()
-                    | json_array().
+                    | json_array()
+                    | json_preencoded().
 
 -type json_array()  :: [json_value()].
 -type json_string() :: atom() | binary().
@@ -32,6 +33,8 @@
                         | #{json_string() => json_value()}.
 
 -endif.
+
+-type json_preencoded() :: {json, Json::iodata()}.
 
 -type jiffy_decode_result() :: json_value()
                         | {has_trailer, json_value(), binary()}.

--- a/test/jiffy_18_preencode_tests.erl
+++ b/test/jiffy_18_preencode_tests.erl
@@ -17,6 +17,11 @@ gen(ok, {E1, J, E2}) ->
     {msg("~p", [E1]), [
         {"Encode", ?_assertEqual(J, enc(E1))},
         {"Decode", ?_assertEqual(E2, dec(J))}
+    ]};
+
+gen(ok, {E, J}) ->
+    {msg("~p", [E]), [
+        {"Encode", ?_assertEqual(J, enc(E))}
     ]}.
 
 %% gen(error, E) ->
@@ -45,7 +50,46 @@ cases(ok) ->
         , { [ {json, JSON}, {json, JSON} ], <<"[[1,\"a\"],[1,\"a\"]]">>, [ EJSON, EJSON ]}
         , { {[ {<<"a">>, {json, JSON}} ]}, <<"{\"a\":[1,\"a\"]}">>, {[ {<<"a">>, EJSON} ]}}
         ],
-    TopTests ++ BuriedTests.
+
+    PartialArray1 = jiffy:partial_encode([ 2, 3 ], []),
+    PartialArray2 = jiffy:partial_encode([], []),
+    PartialArray3 = jiffy:partial_encode([ 5 ], []),
+    PartialArrayTests =
+        [ {[ PartialArray1 ], <<"[2,3]">>}
+        , {[ 1, PartialArray1 ], <<"[1,2,3]">>}
+        , {[ PartialArray1, 4 ], <<"[2,3,4]">>}
+        , {[ 1, PartialArray1, 4 ], <<"[1,2,3,4]">>}
+        , {[ PartialArray2 ], <<"[]">>}
+        , {[ 1, PartialArray2 ], <<"[1]">>}
+        , {[ PartialArray2, 4 ], <<"[4]">>}
+        , {[ 1, PartialArray2, 4 ], <<"[1,4]">>}
+        , {[ PartialArray1, PartialArray2 ], <<"[2,3]">>}
+        , {[ PartialArray2, PartialArray1 ], <<"[2,3]">>}
+        , {[ PartialArray1, PartialArray1 ], <<"[2,3,2,3]">>}
+        , {[ PartialArray2, PartialArray2 ], <<"[]">>}
+        , {[ PartialArray1, PartialArray3 ], <<"[2,3,5]">>}
+        , {[ 1, PartialArray1, 4, PartialArray3, 6 ], <<"[1,2,3,4,5,6]">>}
+        ],
+
+    PartialObject1 = jiffy:partial_encode({[ {<<"ii">>, <<"two">>}, {<<"iii">>, 3} ]}, []),
+    PartialObject2 = jiffy:partial_encode({[]}, []),
+    PartialObject3 = jiffy:partial_encode({[ {<<"v">>, [ 1, 2, 3, 4, 5 ]} ]}, []),
+    PartialObjectTests =
+        [ {{[ PartialObject1 ]}, <<"{\"ii\":\"two\",\"iii\":3}">>}
+        , {{[ {<<"i">>, 1}, PartialObject1 ]}, <<"{\"i\":1,\"ii\":\"two\",\"iii\":3}">>}
+        , {{[ PartialObject1, {<<"iv">>, 4} ]}, <<"{\"ii\":\"two\",\"iii\":3,\"iv\":4}">>}
+        , {{[ {<<"i">>, 1}, PartialObject1, {<<"iv">>, 4} ]}, <<"{\"i\":1,\"ii\":\"two\",\"iii\":3,\"iv\":4}">>}
+        , {{[ PartialObject2 ]}, <<"{}">>}
+        , {{[ {<<"i">>, 1}, PartialObject2 ]}, <<"{\"i\":1}">>}
+        , {{[ PartialObject2, {<<"iv">>, 4} ]}, <<"{\"iv\":4}">>}
+        , {{[ {<<"i">>, 1}, PartialObject2, {<<"iv">>, 4} ]}, <<"{\"i\":1,\"iv\":4}">>}
+        , {{[ PartialObject1, PartialObject2 ]}, <<"{\"ii\":\"two\",\"iii\":3}">>}
+        , {{[ PartialObject2, PartialObject1 ]}, <<"{\"ii\":\"two\",\"iii\":3}">>}
+        , {{[ PartialObject2, PartialObject2 ]}, <<"{}">>}
+        , {{[ PartialObject1, PartialObject3 ]}, <<"{\"ii\":\"two\",\"iii\":3,\"v\":[1,2,3,4,5]}">>}
+        ],
+
+    TopTests ++ BuriedTests ++ PartialArrayTests ++ PartialObjectTests.
 
 %% cases(error) ->
 %%     [ {json, true}

--- a/test/jiffy_18_preencode_tests.erl
+++ b/test/jiffy_18_preencode_tests.erl
@@ -1,0 +1,53 @@
+-module(jiffy_18_preencode_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+-include("jiffy_util.hrl").
+
+
+preencode_success_test_() ->
+    [gen(ok, Case) || Case <- cases(ok)].
+
+
+%% preencode_failure_test_() ->
+%%     [gen(error, Case) || Case <- cases(error)].
+
+
+gen(ok, {E1, J, E2}) ->
+    {msg("~p", [E1]), [
+        {"Encode", ?_assertEqual(J, enc(E1))},
+        {"Decode", ?_assertEqual(E2, dec(J))}
+    ]}.
+
+%% gen(error, E) ->
+%%     {msg("Error: ~p", [E]), [
+%%         ?_assertThrow({error, _}, enc(E))
+%%     ]}.
+
+
+cases(ok) ->
+    TopTests =
+        lists:map(
+          fun (EJSON) ->
+                  JSON = enc(EJSON),
+                  {{json, JSON}, JSON, EJSON}
+          end, [ 123
+               , <<"hello world">>
+               , true
+               , false
+               , {[ {<<"a">>, <<"apple">>}, {<<"b">>, <<"banana">>} ]}
+               ]),
+    EJSON = [ 1, <<"a">> ],
+    JSON = enc(EJSON),
+    BuriedTests =
+        [ { [ {json, JSON} ], <<"[[1,\"a\"]]">>, [ EJSON ]}
+        , { [ 1, {json, JSON}, 3 ], <<"[1,[1,\"a\"],3]">>, [ 1, EJSON, 3 ]}
+        , { [ {json, JSON}, {json, JSON} ], <<"[[1,\"a\"],[1,\"a\"]]">>, [ EJSON, EJSON ]}
+        , { {[ {<<"a">>, {json, JSON}} ]}, <<"{\"a\":[1,\"a\"]}">>, {[ {<<"a">>, EJSON} ]}}
+        ],
+    TopTests ++ BuriedTests.
+
+%% cases(error) ->
+%%     [ {json, true}
+%%     , {json, "true"}
+%%     ].


### PR DESCRIPTION
This pull request is a rewrite of #139 that uses @davisp's approach to including pre-encoded JSON in the input.

It adds a new function `jiffy:partial_encode/2` that takes an array or object and returns a term that can later be included as part of the input in a future `jiffy:encode` call.
```erlang
PartialArray = jiffy:partial_encode([ 1, 2 ], []).
PartialObject = jiffy:partial_encode({[ {one, 1} ]}, []).
iolist_to_binary(jiffy:encode([ [ PartialArray, 3 ], {[ PartialObject, {two, 2} ]} ])).
%% => <<"[[1,2,3],{\"one\":1,\"two\":2}]">>
```

It uses the atoms `$partial_array$` and `$partial_object$` to mark these partially-encoded values. For the partially-encoded array we could technically use `json` but I added `$partial_array$` because the partially-encoded array is not well-formed JSON while the JSON in `{json, Json}` is, and I thought it was worth distinguishing the two.

I did not test my code with native Erlang maps but I believe it will work if the tuple `{Key, Value}` returned by `jiffy_partial_encode` is added to the map by `map:put(Key, Value, Map)`.