### PR TITLE
Optimize encoding performance in Erlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ Data Format
     [true, 1.0]                -> [true, 1.0]    -> [true, 1.0]
     {[]}                       -> {}             -> {[]}
     {[{foo, bar}]}             -> {"foo": "bar"} -> {[{<<"foo">>, <<"bar">>}]}
+    {[{123, bar}]}             -> {"123": "bar"} -> {[{<<"123">>, <<"bar">>}]}
     {[{<<"foo">>, <<"bar">>}]} -> {"foo": "bar"} -> {[{<<"foo">>, <<"bar">>}]}
     #{<<"foo">> => <<"bar">>}  -> {"foo": "bar"} -> #{<<"foo">> => <<"bar">>}
+    #{123 => <<"bar">>}        -> {"123": "bar"} -> #{<<"123">> => <<"bar">>}
 
-N.B. The last entry in this table is only valid for VM's that support
+N.B. The last two entries in this table are only valid for VM's that support
 the `maps` data type (i.e., 17.0 and newer) and client code must pass
 the `return_maps` option to `jiffy:decode/2`.
 

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -827,8 +827,7 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                     ret = enc_error(e, "internal_error");
                     goto done;
                 }
-            }
-            else {
+            } else {
                 if(!enc_string(e, tuple[0])) {
                     ret = enc_obj_error(e, "invalid_object_member_key", tuple[0]);
                     goto done;

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -814,9 +814,25 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 ret = enc_obj_error(e, "invalid_object_member_arity", item);
                 goto done;
             }
-            if(!enc_string(e, tuple[0])) {
-                ret = enc_obj_error(e, "invalid_object_member_key", tuple[0]);
-                goto done;
+            if(enif_get_int64(env, tuple[0], &lval)) {
+                if (!enc_char(e, '"')) {
+                    ret = enc_error(e, "internal_error");
+                    goto done;
+                }
+                if(!enc_long(e, lval)) {
+                    ret = enc_obj_error(e, "invalid_object_member_key", tuple[0]);
+                    goto done;
+                }
+                if (!enc_char(e, '"')) {
+                    ret = enc_error(e, "internal_error");
+                    goto done;
+                }
+            }
+            else {
+                if(!enc_string(e, tuple[0])) {
+                    ret = enc_obj_error(e, "invalid_object_member_key", tuple[0]);
+                    goto done;
+                }
             }
             if(!enc_colon(e)) {
                 ret = enc_error(e, "internal_error");

--- a/test/jiffy_07_compound_tests.erl
+++ b/test/jiffy_07_compound_tests.erl
@@ -9,7 +9,8 @@
 
 
 compound_success_test_() ->
-    [gen(ok, Case) || Case <- cases(ok)].
+    [gen(ok, Case) || Case <- cases(ok)] ++ 
+    [gen(special_encoding, Case) || Case <- cases(special_encoding)].
 
 
 compound_failure_test_() ->
@@ -22,6 +23,11 @@ gen(ok, {J1, E, J2}) ->
     {msg("~s", [J1]), [
         {"Decode", ?_assertEqual(E, dec(J1))},
         {"Encode", ?_assertEqual(J2, enc(E))}
+    ]};
+
+gen(special_encoding, {J, E}) ->
+    {msg("~s", [J]), [
+        {"Encode", ?_assertEqual(J, enc(E))}
     ]};
 
 gen(error, J) ->
@@ -51,6 +57,11 @@ cases(ok) ->
                 null
             ]
         }
+    ];
+
+cases(special_encoding) ->
+    [
+        {<<"{\"123\":\"foo\"}">>, {[{123, <<"foo">>}]}}
     ];
 
 cases(error) ->

--- a/test/jiffy_12_error_tests.erl
+++ b/test/jiffy_12_error_tests.erl
@@ -71,13 +71,10 @@ enc_invalid_object_member_key_test_() ->
     E1 = {1, true},
     {"invalid_object_member_key", [
         {"Bad string", enc_error(Type, <<143>>, {[{<<143>>, true}]})},
-        {"Basic", enc_error(Type, 1, {[{1, true}]})},
         {"Basic", enc_error(Type, [1], {[{[1], true}]})},
         {"Basic", enc_error(Type, {[{foo,bar}]}, {[{{[{foo,bar}]}, true}]})},
         {"Second", enc_error(Type, 1, {[{bar, baz}, E1]})},
-        {"Nested", enc_error(Type, 1, {[{bar,{[E1]}}]})},
         {"Nested", enc_error(Type, 1, {[{bar,{[{baz, 1}, E1]}}]})},
-        {"In List", enc_error(Type, 1, [{[E1]}])},
         {"In List", enc_error(Type, 1, [{[{bang, true}, E1]}])}
     ]}.
 


### PR DESCRIPTION
Right now jiffy requires keys in maps or keyword tuples to be strings to be successfully encoded.

If existing keys in map are integers - whole map should be recreated with keys converted to integers - which is huge overhead in terms of CPU/RAM usage.

This patch allows integer to be serialized into JSON as map's key as well.

*May be* it should be enabled only when some option is passed to encoder.