### PR TITLE
Cleanup after new enc lands

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,9 +23,7 @@
     {"darwin10.*-32$", "CXXFLAGS", "-m32"},
     {"darwin10.*-32$", "LDFLAGS", "-arch i386"},
 
-    %% This will merge into basho/rebar/rebar.config eventually
-    {"win32", "CFLAGS", "/Wall /DWIN32 /D_WINDOWS /D_WIN32 /DWINDOWS"},
-    {"win32", "CXXFLAGS", "-Ic_src/ -g -Wall -O3"}
+    {"win32", "CXXFLAGS", "$CXXFLAGS /O2 /DNDEBUG"}
 ]}.
 
 {erl_opts, [


### PR DESCRIPTION
Once https://github.com/davisp/erlang-native-compiler/pull/1 lands, this change to `rebar.config` will clean up Windows compile flags.