### PR TITLE
Atom `undefined` is not encodable

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -759,6 +759,9 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 ret = enc_error(e, "false");
                 goto done;
             }
+        } else if(enif_compare(curr, e->atoms->atom_undefined) == 0) {
+            ret = enc_obj_error(e, "invalid_ejson", curr);
+            goto done;
         } else if(enif_is_binary(env, curr)) {
             if(!enc_string(e, curr)) {
                 ret = enc_obj_error(e, "invalid_string", curr);

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -34,6 +34,7 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_escape_forward_slashes = make_atom(env, "escape_forward_slashes");
     st->atom_dedupe_keys = make_atom(env, "dedupe_keys");
     st->atom_copy_strings = make_atom(env, "copy_strings");
+    st->atom_undefined = make_atom(env, "undefined");
 
     // Markers used in encoding
     st->ref_object = make_atom(env, "$object_ref$");

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -37,6 +37,7 @@ typedef struct {
     ERL_NIF_TERM    atom_escape_forward_slashes;
     ERL_NIF_TERM    atom_dedupe_keys;
     ERL_NIF_TERM    atom_copy_strings;
+    ERL_NIF_TERM    atom_undefined;
 
     ERL_NIF_TERM    ref_object;
     ERL_NIF_TERM    ref_array;

--- a/test/jiffy_12_error_tests.erl
+++ b/test/jiffy_12_error_tests.erl
@@ -6,43 +6,48 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
+-define(ENC_ERROR(Type, Obj, Case),
+        ?_assertEqual({error, {Type, Obj}}, (catch jiffy:encode(Case)))).
+
+
 enc_invalid_ejson_test_() ->
     Type = invalid_ejson,
     Ref = make_ref(),
     {"invalid_ejson", [
-        {"Basic", enc_error(Type, Ref, Ref)},
-        {"Nested", enc_error(Type, {Ref, Ref}, {Ref, Ref})}
+        {"the atom 'undefined'", ?ENC_ERROR(Type, undefined, undefined)},
+        {"Basic", ?ENC_ERROR(Type, Ref, Ref)},
+        {"Nested", ?ENC_ERROR(Type, {Ref, Ref}, {Ref, Ref})}
     ]}.
 
 
 enc_invalid_string_test_() ->
     Type = invalid_string,
     {"invalid_string", [
-        {"Bare strign", enc_error(Type, <<143>>, <<143>>)},
-        {"List element", enc_error(Type, <<143>>, [<<143>>])},
-        {"Bad obj value", enc_error(Type, <<143>>, {[{foo, <<143>>}]})}
+        {"Bare strign", ?ENC_ERROR(Type, <<143>>, <<143>>)},
+        {"List element", ?ENC_ERROR(Type, <<143>>, [<<143>>])},
+        {"Bad obj value", ?ENC_ERROR(Type, <<143>>, {[{foo, <<143>>}]})}
     ]}.
 
 enc_invalid_object_test_() ->
     Type = invalid_object,
     Ref = make_ref(),
     {"invalid_object", [
-        {"Number", enc_error(Type, {1}, {1})},
-        {"Ref", enc_error(Type, {Ref}, {Ref})},
-        {"Tuple", enc_error(Type, {{[]}}, {{[]}})},
-        {"Atom", enc_error(Type, {foo}, {foo})}
+        {"Number", ?ENC_ERROR(Type, {1}, {1})},
+        {"Ref", ?ENC_ERROR(Type, {Ref}, {Ref})},
+        {"Tuple", ?ENC_ERROR(Type, {{[]}}, {{[]}})},
+        {"Atom", ?ENC_ERROR(Type, {foo}, {foo})}
     ]}.
 
 
 enc_invalid_object_member_test_() ->
     Type = invalid_object_member,
     {"invalid_object_member", [
-        {"Basic", enc_error(Type, foo, {[foo]})},
-        {"Basic", enc_error(Type, foo, {[{bar, baz}, foo]})},
-        {"Nested", enc_error(Type, foo, {[{bar,{[foo]}}]})},
-        {"Nested", enc_error(Type, foo, {[{bar,{[{baz, 1}, foo]}}]})},
-        {"In List", enc_error(Type, foo, [{[foo]}])},
-        {"In List", enc_error(Type, foo, [{[{bang, true}, foo]}])}
+        {"Basic", ?ENC_ERROR(Type, foo, {[foo]})},
+        {"Basic", ?ENC_ERROR(Type, foo, {[{bar, baz}, foo]})},
+        {"Nested", ?ENC_ERROR(Type, foo, {[{bar,{[foo]}}]})},
+        {"Nested", ?ENC_ERROR(Type, foo, {[{bar,{[{baz, 1}, foo]}}]})},
+        {"In List", ?ENC_ERROR(Type, foo, [{[foo]}])},
+        {"In List", ?ENC_ERROR(Type, foo, [{[{bang, true}, foo]}])}
     ]}.
 
 
@@ -51,18 +56,18 @@ enc_invalid_object_member_arity_test_() ->
     E1 = {foo},
     E2 = {x, y, z},
     {"invalid_object_member", [
-        {"Basic", enc_error(Type, E1, {[E1]})},
-        {"Basic", enc_error(Type, E2, {[E2]})},
-        {"Basic", enc_error(Type, E1, {[{bar, baz}, E1]})},
-        {"Basic", enc_error(Type, E2, {[{bar, baz}, E2]})},
-        {"Nested", enc_error(Type, E1, {[{bar,{[E1]}}]})},
-        {"Nested", enc_error(Type, E2, {[{bar,{[E2]}}]})},
-        {"Nested", enc_error(Type, E1, {[{bar,{[{baz, 1}, E1]}}]})},
-        {"Nested", enc_error(Type, E2, {[{bar,{[{baz, 1}, E2]}}]})},
-        {"In List", enc_error(Type, E1, [{[E1]}])},
-        {"In List", enc_error(Type, E2, [{[E2]}])},
-        {"In List", enc_error(Type, E1, [{[{bang, true}, E1]}])},
-        {"In List", enc_error(Type, E2, [{[{bang, true}, E2]}])}
+        {"Basic", ?ENC_ERROR(Type, E1, {[E1]})},
+        {"Basic", ?ENC_ERROR(Type, E2, {[E2]})},
+        {"Basic", ?ENC_ERROR(Type, E1, {[{bar, baz}, E1]})},
+        {"Basic", ?ENC_ERROR(Type, E2, {[{bar, baz}, E2]})},
+        {"Nested", ?ENC_ERROR(Type, E1, {[{bar,{[E1]}}]})},
+        {"Nested", ?ENC_ERROR(Type, E2, {[{bar,{[E2]}}]})},
+        {"Nested", ?ENC_ERROR(Type, E1, {[{bar,{[{baz, 1}, E1]}}]})},
+        {"Nested", ?ENC_ERROR(Type, E2, {[{bar,{[{baz, 1}, E2]}}]})},
+        {"In List", ?ENC_ERROR(Type, E1, [{[E1]}])},
+        {"In List", ?ENC_ERROR(Type, E2, [{[E2]}])},
+        {"In List", ?ENC_ERROR(Type, E1, [{[{bang, true}, E1]}])},
+        {"In List", ?ENC_ERROR(Type, E2, [{[{bang, true}, E2]}])}
     ]}.
 
 
@@ -70,18 +75,13 @@ enc_invalid_object_member_key_test_() ->
     Type = invalid_object_member_key,
     E1 = {1, true},
     {"invalid_object_member_key", [
-        {"Bad string", enc_error(Type, <<143>>, {[{<<143>>, true}]})},
-        {"Basic", enc_error(Type, 1, {[{1, true}]})},
-        {"Basic", enc_error(Type, [1], {[{[1], true}]})},
-        {"Basic", enc_error(Type, {[{foo,bar}]}, {[{{[{foo,bar}]}, true}]})},
-        {"Second", enc_error(Type, 1, {[{bar, baz}, E1]})},
-        {"Nested", enc_error(Type, 1, {[{bar,{[E1]}}]})},
-        {"Nested", enc_error(Type, 1, {[{bar,{[{baz, 1}, E1]}}]})},
-        {"In List", enc_error(Type, 1, [{[E1]}])},
-        {"In List", enc_error(Type, 1, [{[{bang, true}, E1]}])}
+        {"Bad string", ?ENC_ERROR(Type, <<143>>, {[{<<143>>, true}]})},
+        {"Basic", ?ENC_ERROR(Type, 1, {[{1, true}]})},
+        {"Basic", ?ENC_ERROR(Type, [1], {[{[1], true}]})},
+        {"Basic", ?ENC_ERROR(Type, {[{foo,bar}]}, {[{{[{foo,bar}]}, true}]})},
+        {"Second", ?ENC_ERROR(Type, 1, {[{bar, baz}, E1]})},
+        {"Nested", ?ENC_ERROR(Type, 1, {[{bar,{[E1]}}]})},
+        {"Nested", ?ENC_ERROR(Type, 1, {[{bar,{[{baz, 1}, E1]}}]})},
+        {"In List", ?ENC_ERROR(Type, 1, [{[E1]}])},
+        {"In List", ?ENC_ERROR(Type, 1, [{[{bang, true}, E1]}])}
     ]}.
-
-
-
-enc_error(Type, Obj, Case) ->
-    ?_assertEqual({error, {Type, Obj}}, (catch jiffy:encode(Case))).


### PR DESCRIPTION
At least in 0.14.7 Jiffy would encode `undefined` into `<<"\"undefined\"">>`.
This makes jiffy return an error instead.