### PR TITLE
Tighten string buffer size calculation in enc_string.

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -307,10 +307,7 @@ enc_string(Encoder* e, ERL_NIF_TERM val)
                     if(uval < 0) {
                         return 0;
                     }
-                    esc_extra += utf8_esc_len(uval);
-                    if(ulen < 0) {
-                        return 0;
-                    }
+                    esc_extra += utf8_esc_len(uval) - ulen;
                 }
                 i += ulen;
         }


### PR DESCRIPTION
This is a trivial improvement, but in enc_string, the calculated esc_extra value for the enc_ensure call can be larger than necessary when using the `uescape` flag.

When "\u"-escaping a Unicode character, the esc_extra value doesn't need to include the number of bytes in the input string.  That is, if a three-byte UTF-8 character is being escaped to a six-byte "\uXXXX" sequence, esc_extra only needs to be increased by 3.