### PR TITLE
Add missing option for copy strings

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -40,6 +40,7 @@
                         | use_nil
                         | return_trailer
                         | dedupe_keys
+                        | copy_strings
                         | {null_term, any()}
                         | {bytes_per_iter, non_neg_integer()}
                         | {bytes_per_red, non_neg_integer()}.


### PR DESCRIPTION
Without this, call to decode with copy_strings option in an
application will make Dialyzer complain when using the exported type for options