### PR TITLE
Add xmerl dependency into config to be included in an relase

### DIFF
--- a/src/jiffy.app.src
+++ b/src/jiffy.app.src
@@ -2,7 +2,7 @@
     {description, "JSON Decoder/Encoder."},
     {vsn, "0.15.1"},
     {registered, []},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, xmerl]},
     {maintainers, ["Paul J. Davis"]},
     {licenses, ["MIT", "BSD"]},
     {links, [{"GitHub", "https://github.com/davisp/jiffy"}]},


### PR DESCRIPTION
I have a problem when using `jiffy` as a dependency in a release (undefined `xmerl_ucs:is_unicode/1`) without explicitly listing `xmerl` as a dependency. This small change should do the job, Please let me know if I missed something.

Cheers and thanks for this great JSON library!