### PR TITLE
Visual Studio 2019 fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Unifying line endings so tests can pass on Windows
+*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.d
 *.o
 *.so
+*.pdb
+*.dll
+*.exp
+*.lib
 _build
 compile_commands.json
 deps

--- a/c_src/termstack.c
+++ b/c_src/termstack.c
@@ -8,6 +8,10 @@
 #include "jiffy.h"
 #include "termstack.h"
 
+#if WINDOWS || WIN32
+#define inline 
+#endif
+
 ERL_NIF_TERM
 termstack_save(ErlNifEnv* env, TermStack* stack)
 {


### PR DESCRIPTION
This is to resolve issues building/running/testing on Windows 10/VS2019. Two points:
1. Line ending behaviour of git messes with the expected failure positions of a few tests, so unifying around LF is to fix this. (I wonder if the JSON should actually test both though).
2. "inline" keyword breaks the linker when used on functions used between modules. This only occurs in termstack so has been preprocessed out there.

Miscellaneous updates to ensure not committing lots of build time mess as well.

With the above using "x64 Native Tools Command Prompt" it passes all tests against the official erlang builds.

It's not the nicest, and the line ending thing in particular is slightly confusing, so any input on how better to resolve it is most welcome.