### PR TITLE
Export 'encode_options/0' and 'decode_options/0' types

### DIFF
--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -56,8 +56,8 @@
 -type decode_options() :: [decode_option()].
 -type encode_options() :: [encode_option()].
 
+-export_type([decode_options/0, encode_options/0]).
 -export_type([json_value/0, jiffy_decode_result/0]).
-
 
 -spec decode(iolist() | binary()) -> jiffy_decode_result().
 decode(Data) ->


### PR DESCRIPTION
The types may be used in a wrapper module, such as `emqx_json`:

```
-type(encode_options() :: jiffy:encode_options()).
-spec(encode(json_term(), encode_options()) -> json_text()).
encode(Term, Opts) -> jiffy:encode(Term, Opts).
```