### PR TITLE
Force Windows to export inlined functions

### DIFF
--- a/c_src/termstack.h
+++ b/c_src/termstack.h
@@ -6,6 +6,12 @@
 
 #include "erl_nif.h"
 
+#ifdef _WIN32
+#define JIFFY_EXPORT __declspec(dllexport)
+#else
+#define JIFFY_EXPORT
+#endif
+
 #define SMALL_TERMSTACK_SIZE 16
 
 typedef struct {
@@ -21,8 +27,8 @@ ERL_NIF_TERM termstack_save(ErlNifEnv* env, TermStack* stack);
 int termstack_restore(ErlNifEnv* env, ERL_NIF_TERM from, TermStack* stack);
 void termstack_destroy(TermStack* stack);
 
-void termstack_push(TermStack* stack, ERL_NIF_TERM term);
-ERL_NIF_TERM termstack_pop(TermStack* stack);
-int termstack_is_empty(TermStack* stack);
+JIFFY_EXPORT void termstack_push(TermStack* stack, ERL_NIF_TERM term);
+JIFFY_EXPORT ERL_NIF_TERM termstack_pop(TermStack* stack);
+JIFFY_EXPORT int termstack_is_empty(TermStack* stack);
 
 #endif


### PR DESCRIPTION
By default, MSVC won't export an inlined function. This fixes that.