### PR TITLE
Add option max_levels to decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ The options for decode are:
   the decode result is still in use.
 * `{max_levels, N}` where N &gt;= 0 - This controls when to stop decoding
   by depth, after N levels are decoded, the rest is returned as a
-  `{json, binary()}`. Note that json validation is relaxed in levels deeper
-  than N.
+  `{json, binary()}`.
 * `{bytes_per_red, N}` where N &gt;= 0 - This controls the number of
   bytes that Jiffy will process as an equivalent to a reduction. Each
   20 reductions we consume 1% of our allocated time slice for the current

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ The options for encode are:
 * `{bytes_per_red, N}` - Refer to the decode options
 * `{bytes_per_iter, N}` - Refer to the decode options
 
+`jiffy:validate/1,2`
+------------------
+
+* `jiffy:validate(IoData)`
+* `jiffy:validate(IoData, Options)`
+
+Performs a fast decode to validate the correct IoData, uses the same Options as
+`jiffy:decode/2` (although some may make no sense).
+Returns a boolean instead of an EJSON.
+
 Data Format
 -----------
 
@@ -138,11 +148,11 @@ Partial JSONs
 instead of some `json_value()`.
 
 These resources hold a `binary()` with the verified JSON data and can be used
-directly, or as a part of a larger ejson in `jiffy:encode/1,2`. These binaries
+directly, or as a part of a larger EJSON in `jiffy:encode/1,2`. These binaries
 won't be reencoded, instead, they will be placed directly in the result.
 
 However, using resources has some limitations: The resource is only valid in
 the node where it was created. If a resource is serialized and deserialized, or
-if it changes nodes back and forth, it will only be still valid if the original
-resource was not GC'd.
+if it changes nodes back and forth, it will only be still valid if the resource
+was not GC'd.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The options for decode are:
   this option will instead allocate new binaries for each string, so
   the original JSON document can be garbage collected even though
   the decode result is still in use.
+* `{max_levels, N}` where N &gt;= 0 - This controls when to stop decoding
+  by depth, after N levels are decoded, the rest is returned as a
+  `{json, binary()}`. Note that json validation is relaxed in levels deeper
+  than N.
 * `{bytes_per_red, N}` where N &gt;= 0 - This controls the number of
   bytes that Jiffy will process as an equivalent to a reduction. Each
   20 reductions we consume 1% of our allocated time slice for the current

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The options for decode are:
   the decode result is still in use.
 * `{max_levels, N}` where N &gt;= 0 - This controls when to stop decoding
   by depth, after N levels are decoded, the rest is returned as a
-  `{json, binary()}`.
+  `Resource::reference()`. Resources have some limitations, check [partial jsons
+  section](#partial-jsons).
 * `{bytes_per_red, N}` where N &gt;= 0 - This controls the number of
   bytes that Jiffy will process as an equivalent to a reduction. Each
   20 reductions we consume 1% of our allocated time slice for the current
@@ -88,6 +89,11 @@ The options for encode are:
 * `use_nil` - Encodes the atom `nil` as `null`.
 * `escape_forward_slashes` - Escapes the `/` character which can be
   useful when encoding URLs in some cases.
+* `partial` - Instead of returning an `iodata()`, returns a
+  `Resource::reference()` which holds the verified raw json. This resource can be used
+  as a block to build more complex jsons, without the need to encode these
+  blocks again. Resources have some limitations, check [partial jsons
+  section](#partial-jsons).
 * `{bytes_per_red, N}` - Refer to the decode options
 * `{bytes_per_iter, N}` - Refer to the decode options
 
@@ -122,4 +128,21 @@ Improvements over EEP0018
 Jiffy should be in all ways an improvement over EEP0018. It no longer
 imposes limits on the nesting depth. It is capable of encoding and
 decoding large numbers and it does quite a bit more validation of UTF-8 in strings.
+
+Partial JSONs
+-------------------------
+
+`jiffy:encode/2` with option `partial` returns a `Resource::reference()`.
+
+`jiffy:decode/2` with option `max_levels` may place a `Resource::reference()`
+instead of some `json_value()`.
+
+These resources hold a `binary()` with the verified JSON data and can be used
+directly, or as a part of a larger ejson in `jiffy:encode/1,2`. These binaries
+won't be reencoded, instead, they will be placed directly in the result.
+
+However, using resources has some limitations: The resource is only valid in
+the node where it was created. If a resource is serialized and deserialized, or
+if it changes nodes back and forth, it will only be still valid if the original
+resource was not GC'd.
 

--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -208,7 +208,13 @@ static int inline
 level_decrease(Decoder* d, ERL_NIF_TERM* value) {
     if (d->max_levels && d->max_levels == --d->current_depth) {
         // Only builds term in threshold
-        *value = wrap_enif_make_sub_binary(d->env, d->arg, d->level_start, (d->i - d->level_start + 1));
+        unsigned ulen = d->i - d->level_start + 1;
+        if(!d->copy_strings) {
+            *value = wrap_enif_make_sub_binary(d->env, d->arg, d->level_start, ulen);
+        } else {
+            char* chrbuf = wrap_enif_make_new_binary(d->env, ulen, value);
+            memcpy(chrbuf, &(d->p[d->level_start]), ulen);
+        }
         return 1;
     }
     return 0;

--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -208,15 +208,7 @@ static int inline
 level_decrease(Decoder* d, ERL_NIF_TERM* value) {
     if (d->max_levels && d->max_levels == --d->current_depth) {
         // Only builds term in threshold
-        ERL_NIF_TERM bin;
-        if(!d->copy_strings) {
-            bin = enif_make_sub_binary(d->env, d->arg, d->level_start, (d->i - d->level_start + 1));
-        } else {
-            unsigned ulen = d->i - d->level_start + 1;
-            char* chrbuf = (char*) enif_make_new_binary(d->env, ulen, &bin);
-            memcpy(chrbuf, &(d->p[d->level_start]), ulen);
-        }
-        *value = enif_make_tuple2(d->env, d->atoms->atom_json, bin);
+        *value = wrap_enif_make_sub_binary(d->env, d->arg, d->level_start, (d->i - d->level_start + 1));
         return 1;
     }
     return 0;

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -683,6 +683,8 @@ encode_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
             continue;
         } else if(get_bytes_per_red(env, val, &(e->bytes_per_red))) {
             continue;
+        } else if(enif_is_identical(val, e->atoms->atom_partial)) {
+            // Ignore, handled in Erlang
         } else {
             return enif_make_badarg(env);
         }
@@ -923,6 +925,11 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
             termstack_push(&stack, curr);
             termstack_push(&stack, e->atoms->ref_array);
             termstack_push(&stack, item);
+        } else if(unwrap(env, curr, &item)) {
+            if(!enc_unknown(e, item)) {
+                ret = enc_error(e, "internal_error");
+                goto done;
+            }
         } else {
             if(!enc_unknown(e, curr)) {
                 ret = enc_error(e, "internal_error");

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -35,6 +35,8 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_escape_forward_slashes = make_atom(env, "escape_forward_slashes");
     st->atom_dedupe_keys = make_atom(env, "dedupe_keys");
     st->atom_copy_strings = make_atom(env, "copy_strings");
+    st->atom_json = make_atom(env, "json");
+    st->atom_max_levels = make_atom(env, "max_levels");
 
     // Markers used in encoding
     st->ref_object = make_atom(env, "$object_ref$");

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -35,7 +35,6 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_escape_forward_slashes = make_atom(env, "escape_forward_slashes");
     st->atom_dedupe_keys = make_atom(env, "dedupe_keys");
     st->atom_copy_strings = make_atom(env, "copy_strings");
-    st->atom_json = make_atom(env, "json");
     st->atom_max_levels = make_atom(env, "max_levels");
 
     // Markers used in encoding
@@ -56,6 +55,15 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
             NULL,
             "encoder",
             enc_destroy,
+            ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER,
+            NULL
+        );
+
+    st->res_wrapper = enif_open_resource_type(
+            env,
+            NULL,
+            "wrapper",
+            wrapper_destroy,
             ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER,
             NULL
         );
@@ -89,7 +97,8 @@ static ErlNifFunc funcs[] =
     {"nif_decode_init", 2, decode_init},
     {"nif_decode_iter", 5, decode_iter},
     {"nif_encode_init", 2, encode_init},
-    {"nif_encode_iter", 3, encode_iter}
+    {"nif_encode_iter", 3, encode_iter},
+    {"nif_wrap_binary", 1, wrap_binary}
 };
 
 ERL_NIF_INIT(jiffy, funcs, &load, &reload, &upgrade, &unload);

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -89,6 +89,7 @@ int unicode_from_pair(int hi, int lo);
 int unicode_uescape(int c, unsigned char* buf);
 int double_to_shortest(unsigned char *buf, size_t size, size_t* len, double val);
 
+char* wrap_enif_make_new_binary(ErlNifEnv* env, size_t size, ERL_NIF_TERM* termp);
 ERL_NIF_TERM wrap_enif_make_sub_binary(ErlNifEnv* env, ERL_NIF_TERM bin_term, size_t pos, size_t size);
 int unwrap(ErlNifEnv* env, ERL_NIF_TERM wrapper_resource, ERL_NIF_TERM* bin_term_p);
 

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -44,7 +44,6 @@ typedef struct {
     ERL_NIF_TERM    atom_escape_forward_slashes;
     ERL_NIF_TERM    atom_dedupe_keys;
     ERL_NIF_TERM    atom_copy_strings;
-    ERL_NIF_TERM    atom_json;
     ERL_NIF_TERM    atom_max_levels;
 
     ERL_NIF_TERM    ref_object;
@@ -52,6 +51,7 @@ typedef struct {
 
     ErlNifResourceType* res_dec;
     ErlNifResourceType* res_enc;
+    ErlNifResourceType* res_wrapper;
 } jiffy_st;
 
 ERL_NIF_TERM make_atom(ErlNifEnv* env, const char* name);
@@ -69,9 +69,11 @@ ERL_NIF_TERM decode_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM decode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM encode_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM wrap_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 void dec_destroy(ErlNifEnv* env, void* obj);
 void enc_destroy(ErlNifEnv* env, void* obj);
+void wrapper_destroy(ErlNifEnv* env, void* obj);
 
 int make_object(ErlNifEnv* env, ERL_NIF_TERM pairs, ERL_NIF_TERM* out,
         int ret_map, int dedupe_keys);
@@ -86,5 +88,8 @@ int unicode_to_utf8(int c, unsigned char* buf);
 int unicode_from_pair(int hi, int lo);
 int unicode_uescape(int c, unsigned char* buf);
 int double_to_shortest(unsigned char *buf, size_t size, size_t* len, double val);
+
+ERL_NIF_TERM wrap_enif_make_sub_binary(ErlNifEnv* env, ERL_NIF_TERM bin_term, size_t pos, size_t size);
+int unwrap(ErlNifEnv* env, ERL_NIF_TERM wrapper_resource, ERL_NIF_TERM* bin_term_p);
 
 #endif // Included JIFFY_H

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -44,6 +44,8 @@ typedef struct {
     ERL_NIF_TERM    atom_escape_forward_slashes;
     ERL_NIF_TERM    atom_dedupe_keys;
     ERL_NIF_TERM    atom_copy_strings;
+    ERL_NIF_TERM    atom_json;
+    ERL_NIF_TERM    atom_max_levels;
 
     ERL_NIF_TERM    ref_object;
     ERL_NIF_TERM    ref_array;

--- a/c_src/wrapper.c
+++ b/c_src/wrapper.c
@@ -1,0 +1,77 @@
+// This file is part of Jiffy released under the MIT license.
+// See the LICENSE file for more information.
+
+#include "erl_nif.h"
+#include "jiffy.h"
+
+typedef struct {
+    // The Wrapper is a struct intended to be used as a resource to hold a
+    // binary that's been validated by jiffy to be a valid JSON value
+
+    ErlNifEnv*      env;    // Process independent env to hold the wrapped binary
+    ERL_NIF_TERM    bin;
+} Wrapper;
+
+static ERL_NIF_TERM
+wrap_new(ErlNifEnv* process_env, ErlNifEnv* process_independent_env, ERL_NIF_TERM binary)
+{
+    jiffy_st* st = (jiffy_st*) enif_priv_data(process_env);
+
+    Wrapper* wrapper_p = enif_alloc_resource(st->res_wrapper, sizeof(Wrapper));
+    ERL_NIF_TERM wrapper_term = enif_make_resource(process_env, wrapper_p);
+    enif_release_resource(wrapper_p);
+
+    wrapper_p->env = process_independent_env;
+    wrapper_p->bin = binary;
+
+    return wrapper_term;
+}
+
+ERL_NIF_TERM
+wrap_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    if(argc != 1) {
+        return enif_make_badarg(env);
+    }
+
+    ERL_NIF_TERM binary = argv[0];
+    if(!enif_is_binary(env, binary)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifEnv* process_independent_env = enif_alloc_env();
+    ERL_NIF_TERM bin_copy = enif_make_copy(process_independent_env, binary);
+
+    return wrap_new(env, process_independent_env, bin_copy);
+}
+
+ERL_NIF_TERM
+wrap_enif_make_sub_binary(ErlNifEnv* env, ERL_NIF_TERM bin_term, size_t pos, size_t size)
+{
+    ErlNifEnv* process_independent_env = enif_alloc_env();
+    // sub_bin must be created in the same env as the parent binary and then copied
+    ERL_NIF_TERM sub_bin = enif_make_sub_binary(env, bin_term, pos, size);
+    return wrap_new(env, process_independent_env, enif_make_copy(process_independent_env, sub_bin));
+}
+
+int
+unwrap(ErlNifEnv* env, ERL_NIF_TERM wrapper_resource, ERL_NIF_TERM* bin_term_p)
+{
+    jiffy_st* st = (jiffy_st*) enif_priv_data(env);
+
+    Wrapper* wrapper_p = NULL;
+    if(!enif_get_resource(env, wrapper_resource, st->res_wrapper, (void**) &wrapper_p)) {
+        return 0;
+    }
+
+    *bin_term_p = enif_make_copy(env, wrapper_p->bin);
+    return 1;
+}
+
+void
+wrapper_destroy(ErlNifEnv* env, void* obj)
+{
+    Wrapper* wrapper_p = (Wrapper*) obj;
+    enif_free_env(wrapper_p->env);
+}
+

--- a/c_src/wrapper.c
+++ b/c_src/wrapper.c
@@ -49,9 +49,20 @@ ERL_NIF_TERM
 wrap_enif_make_sub_binary(ErlNifEnv* env, ERL_NIF_TERM bin_term, size_t pos, size_t size)
 {
     ErlNifEnv* process_independent_env = enif_alloc_env();
-    // sub_bin must be created in the same env as the parent binary and then copied
+    // sub_bin must be created in the same env as the parent binary and then
+    // copied, segfaults sometimes otherwise
     ERL_NIF_TERM sub_bin = enif_make_sub_binary(env, bin_term, pos, size);
     return wrap_new(env, process_independent_env, enif_make_copy(process_independent_env, sub_bin));
+}
+
+char*
+wrap_enif_make_new_binary(ErlNifEnv* env, size_t size, ERL_NIF_TERM* termp)
+{
+    ErlNifEnv* process_independent_env = enif_alloc_env();
+    ERL_NIF_TERM bin;
+    char* chrbuf = (char*) enif_make_new_binary(process_independent_env, size, &bin);
+    *termp = wrap_new(env, process_independent_env, bin);
+    return chrbuf;
 }
 
 int

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -22,7 +22,7 @@
 -type json_string() :: atom() | binary().
 -type json_number() :: integer() | float().
 %% json_raw() is only returned when using options 'partial' or 'max_levels'
--opaque json_raw()  :: reference().
+-type json_raw()  :: reference().
 
 -ifdef(JIFFY_NO_MAPS).
 

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -16,22 +16,24 @@
                     | json_string()
                     | json_number()
                     | json_object()
-                    | json_array()
-                    | json_raw().
+                    | json_array().
 
--type json_array()  :: [json_value()].
+-type json_array()  :: [json_value()] | json_raw().
 -type json_string() :: atom() | binary().
 -type json_number() :: integer() | float().
--type json_raw()    :: reference(). % Only when decoding with max_levels or encoding with partial
+%% json_raw() is only returned when using options 'partial' or 'max_levels'
+-opaque json_raw()  :: reference().
 
 -ifdef(JIFFY_NO_MAPS).
 
--type json_object() :: {[{json_string(),json_value()}]}.
+-type json_object() :: {[{json_string(),json_value()}]}
+                        | json_raw().
 
 -else.
 
 -type json_object() :: {[{json_string(),json_value()}]}
-                        | #{json_string() => json_value()}.
+                        | #{json_string() => json_value()}
+                        | json_raw().
 
 -endif.
 
@@ -60,7 +62,7 @@
 -type decode_options() :: [decode_option()].
 -type encode_options() :: [encode_option()].
 
--export_type([json_value/0, jiffy_decode_result/0]).
+-export_type([json_value/0, json_raw/0, jiffy_decode_result/0]).
 
 
 -spec decode(iolist() | binary()) -> jiffy_decode_result().
@@ -84,12 +86,12 @@ decode(Data, Opts) when is_list(Data) ->
     decode(iolist_to_binary(Data), Opts).
 
 
--spec encode(json_value()) -> iodata() | reference().
+-spec encode(json_value() | json_raw()) -> iodata() | json_raw().
 encode(Data) ->
     encode(Data, []).
 
 
--spec encode(json_value(), encode_options()) -> iodata() | reference().
+-spec encode(json_value() | json_raw(), encode_options()) -> iodata() | json_raw().
 encode(Data, Options) ->
     ForceUTF8 = lists:member(force_utf8, Options),
     ReturnPartial = lists:member(partial, Options),

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -16,11 +16,13 @@
                     | json_string()
                     | json_number()
                     | json_object()
-                    | json_array().
+                    | json_array()
+                    | json_raw().
 
 -type json_array()  :: [json_value()].
 -type json_string() :: atom() | binary().
 -type json_number() :: integer() | float().
+-type json_raw()    :: {json, binary()}. % Only when decoding with max_levels
 
 -ifdef(JIFFY_NO_MAPS).
 
@@ -42,6 +44,7 @@
                         | dedupe_keys
                         | copy_strings
                         | {null_term, any()}
+                        | {max_levels, non_neg_integer()}
                         | {bytes_per_iter, non_neg_integer()}
                         | {bytes_per_red, non_neg_integer()}.
 

--- a/test/jiffy_01_yajl_tests.erl
+++ b/test/jiffy_01_yajl_tests.erl
@@ -14,9 +14,9 @@ yajl_test_() ->
 
 
 gen({Name, Json, {error, Erl}}) ->
-    {Name, ?_assertError(Erl, jiffy:decode(Json))};
+    {Name, [?_assertEqual(false, jiffy:validate(Json)), ?_assertError(Erl, jiffy:decode(Json))]};
 gen({Name, Json, Erl}) ->
-    {Name, ?_assertEqual(Erl, jiffy:decode(Json))}.
+    {Name, [?_assertEqual(true, jiffy:validate(Json)), ?_assertEqual(Erl, jiffy:decode(Json))]}.
 
 
 read_cases() ->

--- a/test/jiffy_15_return_trailer_tests.erl
+++ b/test/jiffy_15_return_trailer_tests.erl
@@ -15,7 +15,11 @@ trailer_test_() ->
         {<<"1 2 3">>, {has_trailer, 1, <<"2 3">>}}
     ],
     {"Test return_trailer", lists:map(fun({Data, Result}) ->
-        ?_assertEqual(Result, jiffy:decode(Data, Opts))
+        ValidateResult = if is_tuple(Result) -> setelement(2, Result, true);
+                            true -> Result
+                         end,
+        [?_assertEqual(ValidateResult, jiffy:validate(Data, Opts)),
+         ?_assertEqual(Result, jiffy:decode(Data, Opts))]
     end, Cases)}.
 
 -ifndef(JIFFY_NO_MAPS).

--- a/test/jiffy_18_decode_levels_tests.erl
+++ b/test/jiffy_18_decode_levels_tests.erl
@@ -1,0 +1,71 @@
+% This file is part of Jiffy released under the MIT license.
+% See the LICENSE file for more information.
+
+-module(jiffy_18_decode_levels_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+decode_levels_test_() ->
+    MaxOptMaxLevels = 4,
+    Cases = [
+        <<"{\"foo\":\"bar\"}">>,
+        <<"{\"foo\":[\"bar\"]}">>,
+        <<"[[[[]],\"foo\"], [\"bar\", []], [\"baz\"], [[], 1]]">>,
+        <<"{\"foo\":{},\"bar\":{\"baz\":[1,2,3], \"foo2\":{}}}">>
+    ],
+    {"Test max_levels", lists:map(fun(Json) ->
+        [
+         begin
+             EJson = jiffy:decode(Json, [{max_levels, MaxLevels} | Opts]),
+             FullEJson = to_full_json(EJson, MaxLevels, Opts),
+             ?_assertEqual(jiffy:decode(Json, Opts), FullEJson)
+         end || MaxLevels <- lists:seq(1, MaxOptMaxLevels), Opts <- generate_options_groups()]
+    end, Cases)}.
+
+
+-ifndef(JIFFY_NO_MAPS).
+generate_options_groups() -> generate_options_groups([return_maps, copy_strings]).
+-else.
+generate_options_groups() -> generate_options_groups([copy_strings]).
+-endif.
+
+generate_options_groups(AvailableOptions) ->
+    generate_options_groups(AvailableOptions, [[]]).
+generate_options_groups([], Acc) ->
+    Acc;
+generate_options_groups([Option | AvailableOptions], Acc) ->
+    generate_options_groups(AvailableOptions,  [[Option | Group] || Group <- Acc] ++ Acc).
+
+
+to_full_json(Val, MaxDepth, DecodeOptions) ->
+    to_full_json(Val, 0, MaxDepth, DecodeOptions).
+to_full_json(_Val, Depth, MaxDepth, _DecodeOptions) when Depth > MaxDepth ->
+    error(too_deep);
+to_full_json({json, ValueBin}, Depth, MaxDepth, DecodeOptions) ->
+    MaxDepth = Depth,
+    true = is_binary(ValueBin),
+    ByteSize = byte_size(ValueBin),
+    case lists:member(copy_strings, DecodeOptions) of
+        true ->
+            ByteSize = binary:referenced_byte_size(ValueBin);
+        _ ->
+            true = ByteSize < binary:referenced_byte_size(ValueBin)
+    end,
+    jiffy:decode(ValueBin, DecodeOptions);
+to_full_json({Pairs}, Depth, MaxDepth, DecodeOptions) when is_list(Pairs) ->
+    {[{K, to_full_json(V, Depth+1, MaxDepth, DecodeOptions)} || {K, V} <- Pairs]};
+to_full_json(Vals, Depth, MaxDepth, DecodeOptions) when is_list(Vals) ->
+    [to_full_json(V, Depth+1, MaxDepth, DecodeOptions) || V <- Vals];
+to_full_json(Val, Depth, MaxDepth, DecodeOptions) ->
+    maybe_map(Val, Depth, MaxDepth, DecodeOptions).
+
+-ifndef(JIFFY_NO_MAPS).
+maybe_map(Obj, Depth, MaxDepth, DecodeOptions) when is_map(Obj) ->
+    maps:map(fun(_K, V) -> to_full_json(V, Depth+1, MaxDepth, DecodeOptions) end, Obj);
+maybe_map(Val, _Depth, _MaxDepth, _DecodeOptions) ->
+    Val.
+-else.
+maybe_map(Val, _Depth, _MaxDepth, _DecodeOptions) ->
+    Val.
+-endif.
+

--- a/test/jiffy_18_partials_tests.erl
+++ b/test/jiffy_18_partials_tests.erl
@@ -12,7 +12,7 @@ decode_levels_test_() ->
             EJson = jiffy:decode(Json, [{max_levels, MaxLevels} | Opts]),
             FullEJson = to_full_json(EJson, MaxLevels, Opts),
             ?_assertEqual(jiffy:decode(Json, Opts), FullEJson)
-         end || MaxLevels <- lists:seq(1, MaxOptMaxLevels), Opts <- generate_options_groups()]
+         end || MaxLevels <- lists:seq(0, MaxOptMaxLevels), Opts <- generate_options_groups()]
     end, jsons())}.
 
 encode_resources_test_() ->

--- a/test/jiffy_18_partials_tests.erl
+++ b/test/jiffy_18_partials_tests.erl
@@ -1,18 +1,12 @@
 % This file is part of Jiffy released under the MIT license.
 % See the LICENSE file for more information.
 
--module(jiffy_18_decode_levels_tests).
+-module(jiffy_18_partials_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 
 decode_levels_test_() ->
     MaxOptMaxLevels = 4,
-    Cases = [
-        <<"{\"foo\":\"bar\"}">>,
-        <<"{\"foo\":[\"bar\"]}">>,
-        <<"[[[[]],\"foo\"], [\"bar\", []], [\"baz\"], [[], 1]]">>,
-        <<"{\"foo\":{},\"bar\":{\"baz\":[1,2,3], \"foo2\":{}}}">>
-    ],
     {"Test max_levels", lists:map(fun(Json) ->
         [
          begin
@@ -20,13 +14,44 @@ decode_levels_test_() ->
              FullEJson = to_full_json(EJson, MaxLevels, Opts),
              ?_assertEqual(jiffy:decode(Json, Opts), FullEJson)
          end || MaxLevels <- lists:seq(1, MaxOptMaxLevels), Opts <- generate_options_groups()]
-    end, Cases)}.
+    end, jsons())}.
+
+encode_resources_test_() ->
+    {"Test encode resources", lists:map(fun(Json) ->
+        [
+         begin
+             EJsonWithResources = jiffy:decode(Json, [{max_levels, 1} | Opts]),
+             JsonFromResources = jiffy:encode(EJsonWithResources),
+             ?_assertEqual(jiffy:decode(Json, Opts), jiffy:decode(JsonFromResources, Opts))
+         end || Opts <- generate_options_groups()]
+    end, jsons())}.
+
+encode_partials_test_() ->
+    {"Test encode partials", lists:map(fun(Json) ->
+        [
+         begin
+             EJson = jiffy:decode(Json, Opts),
+             PartialResource = jiffy:encode(EJson, [partial]),
+             true = is_reference(PartialResource),
+             PartialIOData = jiffy:encode(PartialResource),
+             ?_assertEqual(EJson, jiffy:decode(PartialIOData, Opts))
+         end || Opts <- generate_options_groups()]
+    end, jsons())}.
+
+
+jsons() ->
+    [
+     <<"{\"foo\":\"bar\"}">>,
+     <<"{\"foo\":[\"bar\"]}">>,
+     <<"[[[[]],\"foo\"], [\"bar\", []], [\"baz\"], [[], 1]]">>,
+     <<"{\"foo\":{},\"bar\":{\"baz\":[1,2,3], \"foo2\":{}}}">>
+    ].
 
 
 -ifndef(JIFFY_NO_MAPS).
-generate_options_groups() -> generate_options_groups([return_maps, copy_strings]).
+generate_options_groups() -> generate_options_groups([return_maps]).
 -else.
-generate_options_groups() -> generate_options_groups([copy_strings]).
+generate_options_groups() -> generate_options_groups([]).
 -endif.
 
 generate_options_groups(AvailableOptions) ->
@@ -41,17 +66,10 @@ to_full_json(Val, MaxDepth, DecodeOptions) ->
     to_full_json(Val, 0, MaxDepth, DecodeOptions).
 to_full_json(_Val, Depth, MaxDepth, _DecodeOptions) when Depth > MaxDepth ->
     error(too_deep);
-to_full_json({json, ValueBin}, Depth, MaxDepth, DecodeOptions) ->
+to_full_json(PartialResource, Depth, MaxDepth, DecodeOptions) when is_reference(PartialResource) ->
     MaxDepth = Depth,
-    true = is_binary(ValueBin),
-    ByteSize = byte_size(ValueBin),
-    case lists:member(copy_strings, DecodeOptions) of
-        true ->
-            ByteSize = binary:referenced_byte_size(ValueBin);
-        _ ->
-            true = ByteSize < binary:referenced_byte_size(ValueBin)
-    end,
-    jiffy:decode(ValueBin, DecodeOptions);
+    IOData = jiffy:encode(PartialResource),
+    jiffy:decode(IOData, DecodeOptions);
 to_full_json({Pairs}, Depth, MaxDepth, DecodeOptions) when is_list(Pairs) ->
     {[{K, to_full_json(V, Depth+1, MaxDepth, DecodeOptions)} || {K, V} <- Pairs]};
 to_full_json(Vals, Depth, MaxDepth, DecodeOptions) when is_list(Vals) ->


### PR DESCRIPTION
This PR adds the option `max_levels` to `jiffy:decode`.
This option allows you to provide a `{max_levels, non_neg_integer()}` as option. Jiffy then decodes un to N levels for the JSON, and the ones deeper than that are returned as `{json, binary()}` instead.

This PR couples nicely with #139, allowing to `jiffy:encode(jiffy:decode(Binary, [{max_levels, X}]))`

Why is it useful?
In my case, I use erlang+jiffy to route streamed jsons to different endpoints based on a routing key that's near the top of the document. Decoding and encoding the whole document every time seems to be wasteful.
A simple test with this shows a great improvement for me, however, I don't know if it'd be worth to include for everyone:
```
2> timer:tc(fun() -> [jiffy:decode(JSON, [return_maps]) || _ <- lists:seq(1, 10000)], ok end).
{2355549,ok}
3> timer:tc(fun() -> [jiffy:decode(JSON, [return_maps, {max_levels, 1}]) || _ <- lists:seq(1, 10000)], ok end).
{564704,ok}
```
