### PR TITLE
Fix \r and \n not supported in JSON value

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -208,7 +208,7 @@ dec_string(Decoder* d, ERL_NIF_TERM* value)
     st = d->i;
 
     while(d->i < d->len) {
-        if(d->p[d->i] < 0x20) {
+        if((d->p[d->i] < 0x20) && (d->p[d->i] != 10) && (d->p[d->i] != 13)) {
             return 0;
         } else if(d->p[d->i] == '\"') {
             d->i++;


### PR DESCRIPTION
This PR fixes the issue that jiffy cannot decode strings that contains `\n` (int 10) `\r` (int 13) characters:

```
(emqx@127.0.0.1)4> jiffy:decode(<<"[\"a\n\"]">>, []).
** exception error: {4,invalid_string}
     in function  jiffy:decode/2 (/Users/emqer/code/emqx-rel/_checkouts/jiffy/src/jiffy.erl, line 71)
```

The example above should return `[<<"a\n">>]`.

