### PR TITLE
Fix LTO check on FreeBSD11

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -24,7 +24,7 @@ case os:type() of
             Else -> Else
         end,
         FLTO_CHECK = "echo 'int main(int argc, char *argv[]) {return 0;}' | "
-                ++ CC ++ " -c -x c -o /dev/null -flto -",
+                ++ CC ++ " -x c -o /dev/null -flto -",
         case os:cmd(FLTO_CHECK) of
             [] ->
                 {port_env, PortEnv} = lists:keyfind(port_env, 1, Config1),


### PR DESCRIPTION
Currently the LTO (link time optimisation) check is done by trying
to compile a single object file with the -flto option. This way the
check does not cover the case that the compiler supports it but the
linker does not.

This can happen for instance on FreeBSD11 with FreeBSD clang version
6.0.0 in combination with GNU ld 2.17.50, where the latter does not
support the -plugin option.

Modify the check by removing the -c flag from the compiler options.