### PR TITLE
rebar.config: add -fPIC

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
         "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "LDFLAGS", "$LDFLAGS $FLTO_FLAG -lstdc++"},
+        "LDFLAGS", "$LDFLAGS $FLTO_FLAG -lstdc++ -fPIC"},
 
     %% OS X Leopard flags for 64-bit
     {"darwin9.*-64$", "CXXFLAGS", "-m64"},


### PR DESCRIPTION
Add -fPIC to avoid the following build failure:

```
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/8.3.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: /tmp/cc0ULrdG.ltrans1.ltrans.o: relocation R_X86_64_PC32 against symbol `dec_destroy' can not be used when making a shared object; recompile with -fPIC
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/8.3.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
sh(/home/buildroot/autobuild/instance-3/output-1/host/bin/x86_64-linux-g++ c_src/decoder.o c_src/encoder.o c_src/jiffy.o c_src/termstack.o c_src/utf8.o c_src/util.o c_src/doubles.o c_src/objects.o c_src/double-conversion/bignum-dtoa.o c_src/double-conversion/bignum.o c_src/double-conversion/cached-powers.o c_src/double-conversion/diy-fp.o c_src/double-conversion/double-conversion.o c_src/double-conversion/fast-dtoa.o c_src/double-conversion/fixed-dtoa.o c_src/double-conversion/strtod.o  -flto -lstdc++ -flto -lstdc++ -shared  -L/home/buildroot/autobuild/instance-3/output-1/host/x86_64-buildroot-linux-uclibc/sysroot/usr/lib/erlang/lib/erl_interface-3.13.1/lib -lei -o priv/jiffy.so)
failed with return code 1 and the following output:
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/8.3.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: /tmp/cc0ULrdG.ltrans1.ltrans.o: relocation R_X86_64_PC32 against symbol `dec_destroy' can not be used when making a shared object; recompile with -fPIC
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/8.3.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status

ERROR: Command [compile] failed!
```

Fixes:
 - http://autobuild.buildroot.org/results/9ac6e1bf9eaf922c0b7f869416ec33f40ed3543c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>