### PR TITLE
Allow overiding of ./enc location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REBAR?=./rebar
-
+ENC?=./enc
 
 all: build
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -17,7 +17,7 @@ Config1 = case lists:keyfind(erl_opts, 1, CONFIG) of
         CONFIG ++ [{erl_opts, ErlOpts}]
 end,
 
-case os:type() of
+Config2 = case os:type() of
     {unix, _} ->
         CC = case os:getenv("CC") of
             false -> "cc";
@@ -36,4 +36,14 @@ case os:type() of
         end;
     _ ->
         Config1
+end,
+
+case os:getenv("ENC") of
+    false ->
+        Config2;
+    ENC ->
+        PreHook = {pre_hooks, [{"", compile, "escript " ++ ENC ++ " compile"}]},
+        PostHook = {post_hooks, [{"", clean, "escript " ++ ENC ++ " compile"}]},
+        Config3 = lists:keyreplace(post_hooks, 1, Config2, PostHook),
+        lists:keyreplace(pre_hooks, 1, Config3, PreHook)
 end.


### PR DESCRIPTION
This PR allows specifying the location of enc compiler to compile jiffy as part of a bigger project. 

# Testing recommendation.

```
mv enc src/

ENC=src/enc make
```
