### PR TITLE
Compile C code also when using Mix

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -39,7 +39,8 @@ Config2 = case os:type() of
 end,
 
 IsRebar3 = code:which(rebar3) /= non_existing,
-case IsRebar3 of
+IsMix = lists:keymember(mix, 1, application:loaded_applications()),
+case IsRebar3 or IsMix of
     false ->
         Config2;
     true ->


### PR DESCRIPTION
Hi, congratulations for this new version, now Erlang/OTP 25.0-rc1 is supported!

Jiffy is used as a dependency by [ejabberd](https://github.com/processone/ejabberd), which can be compiled using rebar3 and also with Elixir's mix. 

However, since commit 3fb115039ca6bd43e9163a30892b2682f71e00c4, the C code is only compiled when using rebar3, not when using mix. The Erlang code is correctly compiled in all cases.

This small PR allows jiffy to compile its C code not only when using rebar3, but also when using mix in the parent application.