### PR TITLE
add support for a new architecture loongarch

### DIFF
--- a/c_src/double-conversion/utils.h
+++ b/c_src/double-conversion/utils.h
@@ -94,6 +94,7 @@ int main(int argc, char** argv) {
     defined(__ARMEL__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
     defined(__hppa__) || defined(__ia64__) || \
     defined(__mips__) || \
+    defined(__loongarch__) \
     defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
     defined(_POWER) || defined(_ARCH_PPC) || defined(_ARCH_PPC64) || \
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \


### PR DESCRIPTION
the loongarch architecture can also support this library, hoping to be integrated into it，the following is my demo on this machine:

```
root@f5dafb08baea /w/qxh_demo# uname -a
Linux f5dafb08baea 4.19.190-2.1.lns8.loongarch64 #1 SMP Thu Sep 23 08:52:56 UTC 2021 loongarch64 loongarch64 loongarch64 GNU/Linux
root@f5dafb08baea /w/qxh_demo# cat main.c
double Div_double(double x, double y) { return x / y; }

int main(int argc, char** argv) {
  return Div_double(89255.0, 1e22) == 89255e-22;
}
// Run as follows ./main || echo "correct"
//
```