### PR TITLE
darwin: add support for AppleM1 processor

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,6 +29,11 @@
     {"darwin10.*-32$", "CXXFLAGS", "-m32"},
     {"darwin10.*-32$", "LDFLAGS", "-arch i386"},
 
+    %% OSX M1 Apple silicon
+    {"aarch64-apple-darwin.*", "CFLAGS", "$CFLAGS -arch arm64"},
+    {"aarch64-apple-darwin.*", "CXXFLAGS", "$CXXFLAGS -arch arm64"},
+    {"aarch64-apple-darwin.*", "LDFLAGS", "-arch arm64"},
+
     {"win32", "CXXFLAGS", "$CXXFLAGS /O2 /DNDEBUG"}
 ]}.
 


### PR DESCRIPTION
This was quite annoying thing to debug :) since port_compiler doesn't print link time errors, even with DEBUG=1

![image](https://user-images.githubusercontent.com/6074754/223981928-c94dba73-807a-4de1-a1a7-baa52d58cd87.png)

I tested by first cleaning

```console
$ m -rf priv _build c_src/*.{o,d} c_src/double-conversion/*.{o,d}
```

then in the rebar3 shell, I tested like seen in the screenshot

```console
$ DEBUG=1 rebar3 shell
```