### PR TITLE
Encoding `undefined` Erlang's atom as null in JSON frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The options for encode are:
   surrogate pairs and/or using the replacement character to remove
   broken UTF-8 sequences in data.
 * `use_nil` - Encodes the atom `nil` as `null`.
+* `use_undefined` - Encodes the atom `undefined` as `null`.
 * `escape_forward_slashes` - Escapes the `/` character which can be
   useful when encoding URLs in some cases.
 * `{bytes_per_red, N}` - Refer to the decode options

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -34,6 +34,7 @@ typedef struct {
     int             uescape;
     int             pretty;
     int             use_nil;
+    int             use_undefined;
     int             escape_forward_slashes;
 
     int             shiftcnt;
@@ -77,6 +78,7 @@ enc_new(ErlNifEnv* env)
     e->uescape = 0;
     e->pretty = 0;
     e->use_nil = 0;
+    e->use_undefined = 0;
     e->escape_forward_slashes = 0;
     e->shiftcnt = 0;
     e->count = 0;
@@ -677,6 +679,8 @@ encode_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
             e->escape_forward_slashes = 1;
         } else if(enif_is_identical(val, e->atoms->atom_use_nil)) {
             e->use_nil = 1;
+        } else if(enif_is_identical(val, e->atoms->atom_use_undefined)) {
+            e->use_undefined = 1;
         } else if(enif_is_identical(val, e->atoms->atom_force_utf8)) {
             // Ignore, handled in Erlang
         } else if(get_bytes_per_iter(env, val, &(e->bytes_per_red))) {
@@ -824,6 +828,11 @@ encode_iter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                     goto done;
                 }
             } else if(e->use_nil && enif_is_identical(curr, e->atoms->atom_nil)) {
+                if(!enc_literal(e, "null", 4)) {
+                    ret = enc_error(e, "null");
+                    goto done;
+                }
+            } else if(e->use_undefined && enif_is_identical(curr, e->atoms->atom_undefined)) {
                 if(!enc_literal(e, "null", 4)) {
                     ret = enc_error(e, "null");
                     goto done;

--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -14,6 +14,7 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_ok = make_atom(env, "ok");
     st->atom_error = make_atom(env, "error");
     st->atom_null = make_atom(env, "null");
+    st->atom_undefined = make_atom(env, "undefined");
     st->atom_true = make_atom(env, "true");
     st->atom_false = make_atom(env, "false");
     st->atom_bignum = make_atom(env, "bignum");
@@ -31,6 +32,7 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_has_trailer = make_atom(env, "has_trailer");
     st->atom_nil = make_atom(env, "nil");
     st->atom_use_nil = make_atom(env, "use_nil");
+    st->atom_use_undefined = make_atom(env, "use_undefined");
     st->atom_null_term = make_atom(env, "null_term");
     st->atom_escape_forward_slashes = make_atom(env, "escape_forward_slashes");
     st->atom_dedupe_keys = make_atom(env, "dedupe_keys");

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -23,6 +23,7 @@ typedef struct {
     ERL_NIF_TERM    atom_ok;
     ERL_NIF_TERM    atom_error;
     ERL_NIF_TERM    atom_null;
+    ERL_NIF_TERM    atom_undefined;
     ERL_NIF_TERM    atom_true;
     ERL_NIF_TERM    atom_false;
     ERL_NIF_TERM    atom_bignum;
@@ -40,6 +41,7 @@ typedef struct {
     ERL_NIF_TERM    atom_has_trailer;
     ERL_NIF_TERM    atom_nil;
     ERL_NIF_TERM    atom_use_nil;
+    ERL_NIF_TERM    atom_use_undefined;
     ERL_NIF_TERM    atom_null_term;
     ERL_NIF_TERM    atom_escape_forward_slashes;
     ERL_NIF_TERM    atom_dedupe_keys;

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -49,6 +49,7 @@
                         | pretty
                         | force_utf8
                         | use_nil
+                        | use_undefined
                         | escape_forward_slashes
                         | {bytes_per_iter, non_neg_integer()}
                         | {bytes_per_red, non_neg_integer()}.

--- a/test/jiffy_02_literal_tests.erl
+++ b/test/jiffy_02_literal_tests.erl
@@ -33,6 +33,12 @@ nil_test_() ->
         {"Encode", ?_assertEqual(<<"null">>, enc(nil, [use_nil]))}
     ]}.
 
+undefined_test_() ->
+    {"undefined", [
+        {"Decode", ?_assertEqual(undefined, dec(<<"null">>, [{null_term, undefined}]))},
+        {"Encode", ?_assertEqual(<<"null">>, enc(undefined, [use_undefined]))}
+    ]}.
+
 null_term_test_() ->
     T = [
         {undefined, [{null_term, undefined}]},


### PR DESCRIPTION
The `undefined` atom in Erlang is used as the default value for unset record fields, missing process dictionary entries, or lack of data in most of all the built-in data structures. It is exactly the same concept as null for other modern programming languages (C#, Java, JavaScript), nill (Go, Ruby, Swift), or None (Python, Scala, Rust), etc. 

Whenever encoding such Erlang term containing undefines to the JSON with Jiffy (for instance as a response for some API query), the coder has to write a custom converter for it. It can be something such simple as:

```erlang
undefined_to_null(undefined) -> null;
undefined_to_null(V) -> V.
```
or more complex whenever more nested data structures are passed into it.  

To solve this inconvenience and let us all keep Erlang's world and its conventions separate from formatting data to the JSON, I propose introducing a custom `use_undefined` encoding option. Very similar to `use_nil`,  but converts `undefined` atoms to JSON's nulls in place instead of nils.