### PR TITLE
Optimize rebar compiler settings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,27 +7,12 @@
 ]}.
 
 {port_env, [
-    % Drop -lerl_interface
-    {"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
-    {"win32", "ERL_LDFLAGS", " /LIBPATH:$ERL_EI_LIBDIR ei.lib"},
-
     {".*", "FLTO_FLAG", ""},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
         "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
         "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
-
-    {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "LDFLAGS", "$LDFLAGS $FLTO_FLAG -lstdc++"},
-
-    %% OS X Leopard flags for 64-bit
-    {"darwin9.*-64$", "CXXFLAGS", "-m64"},
-    {"darwin9.*-64$", "LDFLAGS", "-arch x86_64"},
-
-    %% OS X Snow Leopard flags for 32-bit
-    {"darwin10.*-32$", "CXXFLAGS", "-m32"},
-    {"darwin10.*-32$", "LDFLAGS", "-arch i386"},
 
     {"win32", "CXXFLAGS", "$CXXFLAGS /O2 /DNDEBUG"}
 ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -54,7 +54,10 @@ case IsRebar2 of
     false ->
         Config2 ++ [
             {plugins, [{pc, "~> 1.0"}]},
-            {artifacts, ["priv/jiffy.so"]},
+            case os:type() of
+                {win32, _} -> {artifacts, ["priv/jiffy.dll"]};
+                {_, _} -> {artifacts, ["priv/jiffy.so"]}
+            end,
             {provider_hooks, [
                 {post, [
                     {compile, {pc, compile}},


### PR DESCRIPTION
- remove some old settings which are in the default port compiler environment templates
- add rebar2 artifact setting for compiling on Windows