### PR TITLE
Disable exporting internal symbols

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,9 +14,9 @@
     {".*", "FLTO_FLAG", ""},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
+        "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3 -fvisibility=hidden"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
+        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3 -fvisibility=hidden"},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
         "LDFLAGS", "$LDFLAGS $FLTO_FLAG -lstdc++"},


### PR DESCRIPTION
It has been 5,059 days since [the previous report of a segfault](https://github.com/davisp/jiffy/issues/24) in Jiffy.

Apparently, macOS started shipping a framework that gets linked into beam somewhere that has the same `unicode_to_utf8` symbol exported. When loading Jiffy, the `dyld` machinery would end up seeing that symbol and using it instead of the `unicode_to_utf8` internal to Jiffy. The fix is to just make Jiffy symbols all private so there's no runtime symbol resolution.

Thanks to @rnewson for the report and stack trace that diagnosed the issue.