### PR TITLE
Add extra tests and cleanup to increase coverage

### DIFF
--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -64,12 +64,6 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
 }
 
 static int
-reload(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
-{
-    return 0;
-}
-
-static int
 upgrade(ErlNifEnv* env, void** priv, void** old_priv, ERL_NIF_TERM info)
 {
     return load(env, priv, info);
@@ -93,4 +87,4 @@ static ErlNifFunc funcs[] =
     {"nif_encode_iter", 3, encode_iter, 0}
 };
 
-ERL_NIF_INIT(jiffy, funcs, &load, &reload, &upgrade, &unload);
+ERL_NIF_INIT(jiffy, funcs, &load, NULL, &upgrade, &unload);

--- a/test/jiffy_02_literal_tests.erl
+++ b/test/jiffy_02_literal_tests.erl
@@ -43,3 +43,13 @@ null_term_test_() ->
     ],
     {"null_term",
         [?_assertEqual(R, dec(<<"null">>, O)) || {R, O} <- T]}.
+
+truncated_literal_test_() ->
+    [?_assertError(_, dec(V)) || V <- [
+        <<"tru">>,
+        <<"fals">>,
+        <<"nul">>,
+        <<"t">>,
+        <<"f">>,
+        <<"n">>
+    ]].

--- a/test/jiffy_04_string_tests.erl
+++ b/test/jiffy_04_string_tests.erl
@@ -13,6 +13,12 @@ latin1_atom_test_() ->
     Expected = <<"{\"", 195, 164, "\":\"bar\"}">>,
     ?_assertEqual(Expected, jiffy:encode({[{Key, <<"bar">>}]})).
 
+atom_key_test_() ->
+    [
+        ?_assertEqual(<<"{\"foo\":1}">>, enc({[{foo, 1}]})),
+        ?_assertEqual(<<"{\"bar\":2}">>, enc({[{bar, 2}]}))
+    ].
+
 
 string_success_test_() ->
     [gen(ok, Case) || Case <- cases(ok)].

--- a/test/jiffy_06_object_tests.erl
+++ b/test/jiffy_06_object_tests.erl
@@ -73,9 +73,17 @@ cases(error) ->
 % have to ensure we test large object as well not just smaller ones to exercise
 % that path.
 %
+empty_object_maps_test_() ->
+    ?_assertEqual(#{}, dec(<<"{}">>, [return_maps])).
+
 large_object_maps_test_() ->
     Opts = [return_maps],
     [
+        {"200 keys",
+            fun() ->
+                {Json, Expected} = large_obj(200),
+                round_trip(Json, Expected, Opts)
+            end},
         {"20 duplicate keys (10 as 0, 10 as 1)",
             fun() ->
                 KVs = [{I rem 2, I} || I <- lists:seq(1, 20)],

--- a/test/jiffy_16_dedupe_keys_tests.erl
+++ b/test/jiffy_16_dedupe_keys_tests.erl
@@ -95,3 +95,6 @@ dedupe_keys_test_() ->
         Json = jiffy:encode(Data),
         ?_assertEqual(Result, jiffy:decode(Json, Opts))
     end, Cases)}.
+
+dedupe_keys_empty_test() ->
+    ?assertEqual({[]}, jiffy:decode(<<"{}">>, [dedupe_keys])).


### PR DESCRIPTION
Tests are pretty self-explanatory, just a bunch of corner cases like empty objects with `return_maps` we never tested, or props with atom keys. Most fun ones are the truncated literals like `tru`, `nul` etc.

The NIF lifecyle `reload` callback is deprecate to so we an slap a NULL in there instead.

https://www.erlang.org/doc/apps/erts/erl_nif.html

> The fourth argument NULL is ignored. It was earlier used for the deprecated
reload callback which is no longer supported since OTP 20.