### PR TITLE
Add some NIF lifecyle coverage

### DIFF
--- a/test/jiffy_20_lifecycle_tests.erl
+++ b/test/jiffy_20_lifecycle_tests.erl
@@ -1,0 +1,29 @@
+% This file is part of Jiffy released under the MIT license.
+% See the LICENSE file for more information.
+
+-module(jiffy_20_lifecycle_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% This is more of covarage hacking but we're trying exercise some of the
+%% lifecycle callback in jiffy.c
+
+upgrade_test() ->
+    % baseline
+    ?assertEqual(1, jiffy:decode(<<"1">>)),
+    ?assertEqual(<<"1">>, iolist_to_binary(jiffy:encode(1))),
+
+    % soft purge and reload
+    code:purge(jiffy),
+    {module, jiffy} = code:load_file(jiffy),
+
+    % verify
+    ?assertEqual(1, jiffy:decode(<<"1">>)),
+    ?assertEqual(<<"1">>, iolist_to_binary(jiffy:encode(1))),
+
+    % another purge should now evict the old module
+    code:purge(jiffy),
+
+    % verify
+    ?assertEqual(1, jiffy:decode(<<"1">>)),
+    ?assertEqual(<<"1">>, iolist_to_binary(jiffy:encode(1))).


### PR DESCRIPTION
Not 100% if these ever worked right. Resources do have `ERL_NIF_RT_TAKEOVER` specified and we end up re-creating the private context on upgrade so at least let's try to test them with a few purge and reload checks.

Another alternative is to make these `NULL`s and just say that upgrade is not supported.