### PR TITLE
Produce a unity build

### DIFF
--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -1,7 +1,15 @@
 // This file is part of Jiffy released under the MIT license.
 // See the LICENSE file for more information.
+//
+// Note: we're doing a "unity build" pattern here: all sources are compiled as
+// a single translation unit so the compiler can optimize across file
+// boundaries without lto
 
-#include "jiffy.h"
+#include "decoder.c"
+#include "encoder.c"
+#include "objects.c"
+#include "util.c"
+#include "ryu/d2s.c"
 
 static int
 load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)

--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,7 @@
 
 {port_specs, [
     {"priv/jiffy.so", [
-        "c_src/*.c",
-        "c_src/ryu/*.c"
+        "c_src/jiffy.c"
     ]}
 ]}.
 


### PR DESCRIPTION
Include all the .c files jiffy.c and let the compiler do all the possible optimizations. This in the same vein as linking with LTO.

This unexpectedly produced a speed-up in large string encoding:

```
===== With input Issue 90 =====
Name                     ips        average  deviation         median         99th %
jiffy                  99.37       10.06 ms    +/-21.47%        9.63 ms       18.06 ms
jiffy (master)         67.72       14.77 ms     +/-2.57%       14.62 ms       16.13 ms
Comparison:
jiffy                  99.37
jiffy (master)         67.72 - 1.47x slower +4.70 ms
```

Hat tip to @davisp for suggesting this!