### PR TITLE
Header cleanups

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -3,7 +3,6 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -2,7 +2,6 @@
 // See the LICENSE file for more information.
 
 #include <assert.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "jiffy.h"


### PR DESCRIPTION
`include-what-you-use` says we don't need <stdio.h> in decoder and encoder so removing them