### PR TITLE
Fix potential segfault in termstack expansion

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -123,7 +123,7 @@ termstack_push(TermStack* stack, ERL_NIF_TERM term)
 
         if (stack->elements == &stack->__default_elements[0]) {
             ERL_NIF_TERM* elems = enif_alloc(num_bytes);
-            memcpy(elems, stack->elements, num_bytes);
+            memcpy(elems, stack->elements, SMALL_TERMSTACK_SIZE * sizeof(ERL_NIF_TERM));
             stack->elements = elems;
         } else {
             stack->elements = enif_realloc(stack->elements, num_bytes);


### PR DESCRIPTION
When we go from a stack array to a heap in `termstack_push()`, we should copy `stack->size * sizeof(ERL_NIF_TERM)` number of bytes not `num_bytes`. `num_bytes` is the new value which is twice as large.

This means we've been doing dirty reads and copying extra junk data that we didn't need before. If we had used up most of the stack and were right against the limit, and there was some stack protection involed we could have hit a segfault here.