### PR TITLE
Implement SIMD vectorization

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -8,6 +8,7 @@
 #include "erl_nif.h"
 #include "ffc.h"
 #include "jiffy.h"
+#include "jiffy_simd.h"
 #include "jiffy_utf8.h"
 
 #define STACK_SIZE_INC 64
@@ -269,18 +270,9 @@ dec_string(Decoder* d, ERL_NIF_TERM* value)
                     return 0;
             }
         } else if(d->p[d->i] < 0x80) {
-            // Scan ahead plain ASCII as an optimization
-            const unsigned char* JIFFY_RESTRICT p = d->p;
-            size_t idx = d->i + 1;
-            const size_t len = d->len;
-            while(idx < len
-                    && p[idx] >= 0x20
-                    && p[idx] < 0x80
-                    && p[idx] != '\"'
-                    && p[idx] != '\\') {
-                idx++;
-            }
-            d->i = idx;
+            // Scan ahead plain ASCII as an optimization. The first
+            // byte has already been checked, so start at i+1.
+            d->i = jiffy_scan_string_body(d->p, d->len, d->i + 1);
         } else {
             ulen = utf8_validate(&(d->p[d->i]), d->len - d->i);
             if(ulen == 0) {

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "jiffy.h"
+#include "jiffy_simd.h"
 #include "jiffy_utf8.h"
 #include "ryu/ryu.h"
 
@@ -408,13 +409,7 @@ enc_atom(Encoder* e, ERL_NIF_TERM val)
                     i++;
                 }
             } else {
-                while(i < size
-                        && data[i] >= 0x20
-                        && data[i] < 0x80
-                        && data[i] != '\"'
-                        && data[i] != '\\') {
-                    i++;
-                }
+                i = jiffy_scan_string_body(data, size, i);
             }
             size_t run = i - start;
             if(!enc_ensure(e, run)) {
@@ -497,13 +492,7 @@ enc_string(Encoder* e, ERL_NIF_TERM val)
                     i++;
                 }
             } else {
-                while(i < size
-                        && data[i] >= 0x20
-                        && data[i] < 0x80
-                        && data[i] != '\"'
-                        && data[i] != '\\') {
-                    i++;
-                }
+                i = jiffy_scan_string_body(data, size, i);
             }
             size_t run = i - start;
             if(!enc_ensure(e, run)) {

--- a/c_src/jiffy_simd.h
+++ b/c_src/jiffy_simd.h
@@ -1,0 +1,64 @@
+// This file is part of Jiffy released under the MIT license.
+// See the LICENSE file for more information.
+//
+// Structure the scan-ahead logic so it's both readable and so that Clang and
+// GCC will auto-vectorize the code. For the auto-vectorizer we want to have a
+// loop with a known bound and no early exit, which is a bit tricky, since the
+// whole idea is to exit when we find a "stop" character. To get the best of
+// both worlds, scan 32 bytes at a time and then have an outer loop around that
+//
+// We get auto-vectorization by default with Clang (MacOS 15+) and GCC (14+)
+//
+// Clang
+// ===
+// % cc -S -O3 -Rpass='.*vectoriz.*' -I "$ERL_INC" -I c_src  -c c_src/jiffy.c  -o jiffy.s 2>&1 | grep -i -w 'vectorized' | grep simd
+// c_src/jiffy_simd.h:22:61: remark: Vectorized horizontal reduction with cost -112 and with tree size 3 [-Rpass=slp-vectorizer]
+// c_src/jiffy_simd.h:22:61: remark: Vectorized horizontal reduction with cost -87 and with tree size 3 [-Rpass=slp-vectorizer]
+//
+// GCC
+// ====
+// % gcc-14 -S -O3 -fopt-info-vec-all -I "$ERL_INC" -I c_src  -c c_src/jiffy.c -o jiffy.s 2>&1 | grep -i -w 'optimized'| grep simd
+// c_src/jiffy_simd.h:21:23: optimized: loop vectorized using 16 byte vectors
+// c_src/jiffy_simd.h:21:23: optimized: loop vectorized using 16 byte vectors
+// c_src/jiffy_simd.h:21:23: optimized: loop vectorized using 16 byte vectors
+//
+// If we know we'll deploy on the same architecture we're compiling on we can
+// use -march=native and get even better vectorization with 32 byte chunks at a
+// time
+//
+// GCC /w -march=native
+// ====
+// % gcc-14 -march=native -S -O3 -fopt-info-vec-all -I "$ERL_INC" -I c_src  -c c_src/jiffy.c -o jiffy.s 2>&1 | grep -i -w 'optimized'| grep simd
+// c_src/jiffy_simd.h:21:23: optimized: loop vectorized using 32 byte vectors
+// c_src/jiffy_simd.h:21:23: optimized: loop vectorized using 32 byte vectors
+// c_src/jiffy_simd.h:21:23: optimized: loop vectorized using 32 byte vectors
+
+#ifndef JIFFY_SIMD_H
+#define JIFFY_SIMD_H
+
+#define JIFFY_SIMD_BLOCK_SIZE 32
+
+static inline unsigned int
+jiffy_block_has_stop(const unsigned char* JIFFY_RESTRICT p)
+{
+    unsigned int bad = 0;
+    for (int i = 0; i < JIFFY_SIMD_BLOCK_SIZE; i++) {
+        unsigned char c = p[i];
+        bad |= (unsigned)(c < 0x20) | (unsigned)(c >= 0x80) | (unsigned)(c == '"') | (unsigned)(c == '\\');
+    }
+    return bad;
+}
+
+static inline size_t
+jiffy_scan_string_body(const unsigned char* JIFFY_RESTRICT p, size_t len, size_t i)
+{
+    while (i + JIFFY_SIMD_BLOCK_SIZE <= len && !jiffy_block_has_stop(p + i)) {
+        i += JIFFY_SIMD_BLOCK_SIZE;
+    }
+    while (i < len && p[i] >= 0x20 && p[i] < 0x80 && p[i] != '"' && p[i] != '\\') {
+        i++;
+    }
+    return i;
+}
+
+#endif


### PR DESCRIPTION
Structure scan-ahead logic so Clang and GCC will auto-vectorize the code. For the auto-vectorizer we want a loop with a known bound and no early exit, which is a bit tricky, since the whole idea is to exit when we find a "stop" character. To get the best of both worlds we scan 32 bytes at a time, and then have an outer loop around that.

The title and the .h file name is also a subtle joke, as we didn't actually write a single line of SIMD assembly. However, we've shown vectorization takes place (left some command lines in the file as proof) and we still keep the code fairly readable.

To get an even better speed boost someone who knows they'll deploy on certain CPUs could choose to compile with `-march=native` or `-march=core-avx2` or something like that. In that case the auto-vectorizing code may do an even better job and use wider AVX2 registers. Most Intel and AMD CPUs since 2013 or so would support that.

This speeds up string heavy "issue 90" encoding and decoding

Decoding:

```
===== With input Issue 90 =====
Name                     ips        average  deviation         median         99th %
jiffy                  77.74       12.86 ms     +/-3.42%       12.79 ms       14.85 ms
jiffy (master)         58.97       16.96 ms     +/-2.21%       16.89 ms       18.32 ms
Comparison:
jiffy                  77.74
jiffy (master)         58.97 - 1.32x slower +4.09 ms
```

Encoding

```
===== With input Issue 90 =====
Name                     ips        average  deviation         median         99th %
jiffy                 530.82        1.88 ms     +/-7.28%        1.85 ms        2.50 ms
jiffy (master)        136.70        7.32 ms     +/-2.81%        7.28 ms        8.09 ms
Comparison:
jiffy                 530.82
jiffy (master)        136.70 - 3.88x slower +5.43 ms
```

Others didn't change as much, but most, especially for encoding show  about a 1.05 improvement over master