### PR TITLE
Reduce bytes per reduction a bit

### DIFF
--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -6,7 +6,7 @@
 
 #include "erl_nif.h"
 
-#define DEFAULT_BYTES_PER_REDUCTION 20
+#define DEFAULT_BYTES_PER_REDUCTION 10
 
 // This used to be 2000 and in 19.2 was bumped to 4000
 // #define CONTEXT_REDS in erts/emulator/beam/erl_vm.h


### PR DESCRIPTION
A scheduling benchmark test showed we had too high p99 and max values compared with the built-in OTP 27 json

Before
=====

```
[jiffy]
  idle (no workers)            n=2489 p50=997us p95=1.1ms p99=1.2ms max=11.5ms
  12x decode                   n=1679 p50=1.5ms p95=4.4ms p99=10.7ms max=76.7ms
  12x encode                   n=1148 p50=2.8ms p95=7.8ms p99=12.6ms max=32.2ms
  24x decode                   n=1187 p50=2.4ms p95=8.3ms p99=13.9ms max=72.2ms
  24x encode                   n=754 p50=5.0ms p95=10.7ms p99=16.8ms max=30.0ms
  48x decode                   n=750 p50=4.0ms p95=13.8ms p99=27.6ms max=58.7ms
  48x encode                   n=137 p50=35.7ms p95=68.7ms p99=92.4ms max=102.0ms

[json]
  idle (no workers)            n=2500 p50=997us p95=1.1ms p99=1.2ms max=1.7ms
  12x decode                   n=2008 p50=1.0ms p95=3.7ms p99=10.5ms max=50.1ms
  12x encode                   n=1977 p50=1.0ms p95=4.9ms p99=10.3ms max=26.0ms
  24x decode                   n=2173 p50=1.0ms p95=2.8ms p99=5.5ms max=23.8ms
  24x encode                   n=1850 p50=1.1ms p95=5.1ms p99=8.7ms max=67.4ms
  48x decode                   n=1596 p50=1.9ms p95=4.7ms p99=9.3ms max=21.0ms
  48x encode                   n=1698 p50=1.2ms p95=6.2ms p99=11.5ms max=32.9ms
```

After
====

```
[jiffy]
  idle (no workers)            n=2500 p50=998us p95=1.1ms p99=1.2ms max=1.3ms
  12x decode                   n=2302 p50=1.1ms p95=2.0ms p99=3.2ms max=17.0ms
  12x encode                   n=1703 p50=1.8ms p95=3.4ms p99=5.1ms max=11.5ms
  24x decode                   n=1872 p50=1.4ms p95=3.5ms p99=5.2ms max=9.5ms
  24x encode                   n=1183 p50=2.9ms p95=6.1ms p99=10.4ms max=16.7ms

[json]
  idle (no workers)            n=2500 p50=998us p95=1.1ms p99=1.2ms max=2.2ms
  12x decode                   n=2354 p50=1.0ms p95=1.8ms p99=4.0ms max=12.1ms
  12x encode                   n=2239 p50=993us p95=3.1ms p99=5.7ms max=13.5ms
  24x decode                   n=2216 p50=1.0ms p95=2.4ms p99=6.0ms max=15.0ms
  24x encode                   n=2155 p50=1.0ms p95=3.3ms p99=6.8ms max=14.2ms
```