### PR TITLE
Skip-ahead for UTF8 encoding

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -260,7 +260,7 @@ dec_string(Decoder* d, ERL_NIF_TERM* value)
         } else if(d->p[d->i] < 0x80) {
             // Scan ahead plain ASCII as an optimization. The first
             // byte has already been checked, so start at i+1.
-            d->i = jiffy_scan_string_body(d->p, d->len, d->i + 1);
+            d->i = jiffy_scan_ascii_string_body(d->p, d->len, d->i + 1);
         } else {
             ulen = utf8_validate(&(d->p[d->i]), d->len - d->i);
             if(ulen == 0) {

--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -409,7 +409,7 @@ enc_quoted(Encoder* e,
                     i++;
                 }
             } else {
-                i = jiffy_scan_string_body(data, size, i);
+                i = jiffy_scan_ascii_string_body(data, size, i);
             }
             size_t run = i - start;
             if(!enc_ensure(e, run)) {
@@ -424,27 +424,46 @@ enc_quoted(Encoder* e,
                 e->i += unicode_to_utf8((int)data[i], &(e->p[e->i]));
             }
             i++;
-        } else {
-            // UTF-8 2/3/4-byte sequence: validate, then copy as is or
-            // or uencode as \uXXXX
+        } else if(JIFFY_UNLIKELY(e->uescape)) {
             ulen = utf8_validate((unsigned char*)&(data[i]), size - i);
             if(JIFFY_UNLIKELY(ulen == 0)) {
                 return 0;
-            } else if(JIFFY_UNLIKELY(e->uescape)) {
-                uval = utf8_to_unicode((unsigned char*)&(data[i]), size - i);
-                if(uval < 0) {
-                    return 0;
-                }
-                esc_len = unicode_uescape(uval, &(e->p[e->i]));
-                if(esc_len < 0) {
-                    return 0;
-                }
-                e->i += esc_len;
-            } else {
-                memcpy(&e->p[e->i], &data[i], ulen);
-                e->i += ulen;
             }
+            uval = utf8_to_unicode((unsigned char*)&(data[i]), size - i);
+            if(uval < 0) {
+                return 0;
+            }
+            esc_len = unicode_uescape(uval, &(e->p[e->i]));
+            if(esc_len < 0) {
+                return 0;
+            }
+            e->i += esc_len;
             i += ulen;
+        } else {
+            // Non-ASCII UTF-8 . Scan through the run first and then validate
+            // the whole thing, kinda how we do it for ASCII only.
+            start = i;
+            i++;
+            if(e->escape_forward_slashes) {
+                while(i < size
+                        && data[i] >= 0x20
+                        && data[i] != '\"'
+                        && data[i] != '\\'
+                        && data[i] != '/') {
+                    i++;
+                }
+            } else {
+                i = jiffy_scan_utf8_string_body(data, size, i);
+            }
+            size_t run = i - start;
+            if(JIFFY_UNLIKELY(!utf8_validate_range(&data[start], run))) {
+                return 0;
+            }
+            if(JIFFY_UNLIKELY(!enc_ensure(e, run))) {
+                return 0;
+            }
+            memcpy(&(e->p[e->i]), &data[start], run);
+            e->i += run;
         }
     }
 

--- a/c_src/jiffy_simd.h
+++ b/c_src/jiffy_simd.h
@@ -50,12 +50,37 @@ jiffy_block_has_stop(const unsigned char* JIFFY_RESTRICT p)
 }
 
 static inline size_t
-jiffy_scan_string_body(const unsigned char* JIFFY_RESTRICT p, size_t len, size_t i)
+jiffy_scan_ascii_string_body(const unsigned char* JIFFY_RESTRICT p, size_t len, size_t i)
 {
     while (i + JIFFY_SIMD_BLOCK_SIZE <= len && !jiffy_block_has_stop(p + i)) {
         i += JIFFY_SIMD_BLOCK_SIZE;
     }
     while (i < len && p[i] >= 0x20 && p[i] < 0x80 && p[i] != '"' && p[i] != '\\') {
+        i++;
+    }
+    return i;
+}
+
+// Variant of the scan which lets UTF-8 multi-byte sequences pass through. This
+// so we can scan a whole block and then validate it as a block later.
+static inline unsigned int
+jiffy_block_has_utf8_stop(const unsigned char* JIFFY_RESTRICT p)
+{
+    unsigned int bad = 0;
+    for (int i = 0; i < JIFFY_SIMD_BLOCK_SIZE; i++) {
+        unsigned char c = p[i];
+        bad |= (unsigned)(c < 0x20) | (unsigned)(c == '"') | (unsigned)(c == '\\');
+    }
+    return bad;
+}
+
+static inline size_t
+jiffy_scan_utf8_string_body(const unsigned char* JIFFY_RESTRICT p, size_t len, size_t i)
+{
+    while (i + JIFFY_SIMD_BLOCK_SIZE <= len && !jiffy_block_has_utf8_stop(p + i)) {
+        i += JIFFY_SIMD_BLOCK_SIZE;
+    }
+    while (i < len && p[i] >= 0x20 && p[i] != '"' && p[i] != '\\') {
         i++;
     }
     return i;

--- a/c_src/jiffy_utf8.h
+++ b/c_src/jiffy_utf8.h
@@ -236,6 +236,26 @@ utf8_validate(const unsigned char* JIFFY_RESTRICT data, size_t size)
     return 4;
 }
 
+// Validate a whole range UTF-8 codepoints
+static inline int
+utf8_validate_range(const unsigned char* data, size_t size)
+{
+    size_t i = 0;
+    while(i < size) {
+        if(data[i] < 0x80) {
+            i++;
+            // ASCII skip-through
+            continue;
+        }
+        size_t ulen = utf8_validate((unsigned char*)&data[i], size - i);
+        if(ulen == 0) {
+            return 0;
+        }
+        i += ulen;
+    }
+    return 1;
+}
+
 static inline int
 unicode_to_utf8(int c, unsigned char* buf)
 {


### PR DESCRIPTION
Just like we do it for ASCII-only input, this should help unicode-heavy input.

Turned out better than expected:

```
===== With input Encode Twitter =====
Name                                       ips        average  deviation         median         99th %
jiffy (encode-utf8-scan-through)        306.51        3.26 ms    +/-15.30%        3.21 ms        4.31 ms
jiffy (master)                          276.38        3.62 ms    +/-13.79%        3.54 ms        4.58 ms
Comparison:
jiffy (encode-utf8-scan-through)        306.51
jiffy (master)                          276.38 - 1.11x slower +0.36 ms
===== With input Encode UTF-8 escaped =====
Name                                       ips        average  deviation         median         99th %
jiffy (encode-utf8-scan-through)       22.41 K       44.62 us     +/-1.54%       44.49 us       46.63 us
jiffy (master)                         10.12 K       98.78 us     +/-0.75%       98.68 us      100.95 us
Comparison:
jiffy (encode-utf8-scan-through)       22.41 K
jiffy (master)                         10.12 K - 2.21x slower +54.16 us
===== With input Encode UTF-8 unescaped =====
Name                                       ips        average  deviation         median         99th %
jiffy (encode-utf8-scan-through)       23.35 K       42.83 us     +/-1.70%       42.68 us       45.00 us
jiffy (master)                         10.59 K       94.42 us     +/-0.72%       94.30 us       96.42 us
Comparison:
jiffy (encode-utf8-scan-through)       23.35 K
jiffy (master)                         10.59 K - 2.20x slower +51.60 us
```