### PR TITLE
Remove dead yielding code

### DIFF
--- a/c_src/jiffy.c
+++ b/c_src/jiffy.c
@@ -34,7 +34,6 @@ load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
     st->atom_uescape = make_atom(env, "uescape");
     st->atom_pretty = make_atom(env, "pretty");
     st->atom_force_utf8 = make_atom(env, "force_utf8");
-    st->atom_iter = make_atom(env, "iter");
     st->atom_bytes_per_iter = make_atom(env, "bytes_per_iter");
     st->atom_bytes_per_red = make_atom(env, "bytes_per_red");
     st->atom_return_maps = make_atom(env, "return_maps");
@@ -89,13 +88,10 @@ unload(ErlNifEnv* env, void* priv)
 
 // {name, arity, fptr, dirty_flag}
 // dirty flag: 0 (default) | ERL_NIF_DIRTY_JOB_{IO|CPU}_BOUND
-//
 static ErlNifFunc funcs[] =
 {
     {"nif_decode_init", 2, decode_init, 0},
-    {"nif_decode_iter", 5, decode_iter, 0},
-    {"nif_encode_init", 2, encode_init, 0},
-    {"nif_encode_iter", 3, encode_iter, 0}
+    {"nif_encode_init", 2, encode_init, 0}
 };
 
 ERL_NIF_INIT(jiffy, funcs, &load, NULL, &upgrade, &unload);

--- a/c_src/jiffy.h
+++ b/c_src/jiffy.h
@@ -44,7 +44,6 @@ typedef struct {
     ERL_NIF_TERM    atom_uescape;
     ERL_NIF_TERM    atom_pretty;
     ERL_NIF_TERM    atom_force_utf8;
-    ERL_NIF_TERM    atom_iter;
     ERL_NIF_TERM    atom_bytes_per_iter;
     ERL_NIF_TERM    atom_bytes_per_red;
     ERL_NIF_TERM    atom_return_maps;

--- a/src/jiffy.erl
+++ b/src/jiffy.erl
@@ -63,8 +63,6 @@ decode(Data, Opts) when is_binary(Data), is_list(Opts) ->
             error(Error);
         {partial, EJson} ->
             finish_decode(EJson);
-        {iter, {_, Decoder, Val, Objs, Curr}} ->
-            decode_loop(Data, Decoder, Val, Objs, Curr);
         EJson ->
             EJson
     end;
@@ -91,8 +89,6 @@ encode(Data, Options) ->
             error(Error);
         {partial, IOData} ->
             finish_encode(IOData, []);
-        {iter, {Encoder, Stack, IOBuf}} ->
-            encode_loop(Data, Options, Encoder, Stack, IOBuf);
         [Bin] when is_binary(Bin) ->
             Bin;
         RevIOData when is_list(RevIOData) ->
@@ -186,52 +182,11 @@ init() ->
     erlang:load_nif(filename:join(PrivDir, "jiffy"), 0).
 
 
-decode_loop(Data, Decoder, Val, Objs, Curr) ->
-    case nif_decode_iter(Data, Decoder, Val, Objs, Curr) of
-        {error, Error} ->
-            error(Error);
-        {partial, EJson} ->
-            finish_decode(EJson);
-        {iter, {_, NewDecoder, NewVal, NewObjs, NewCurr}} ->
-            decode_loop(Data, NewDecoder, NewVal, NewObjs, NewCurr);
-        EJson ->
-            EJson
-    end.
-
-
-encode_loop(Data, Options, Encoder, Stack, IOBuf) ->
-    ForceUTF8 = lists:member(force_utf8, Options),
-    case nif_encode_iter(Encoder, Stack, IOBuf) of
-        {error, {invalid_string, _}} when ForceUTF8 == true ->
-            FixedData = jiffy_utf8:fix(Data),
-            encode(FixedData, Options -- [force_utf8]);
-        {error, {invalid_object_member_key, _}} when ForceUTF8 == true ->
-            FixedData = jiffy_utf8:fix(Data),
-            encode(FixedData, Options -- [force_utf8]);
-        {error, Error} ->
-            error(Error);
-        {partial, IOData} ->
-            finish_encode(IOData, []);
-        {iter, {NewEncoder, NewStack, NewIOBuf}} ->
-            encode_loop(Data, Options, NewEncoder, NewStack, NewIOBuf);
-        [Bin] when is_binary(Bin) ->
-            Bin;
-        RevIOData when is_list(RevIOData) ->
-            lists:reverse(RevIOData)
-    end.
-
-
 not_loaded(Line) ->
     erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).
 
 nif_decode_init(_Data, _Opts) ->
     ?NOT_LOADED.
 
-nif_decode_iter(_Data, _Decoder, _, _, _) ->
-    ?NOT_LOADED.
-
 nif_encode_init(_Data, _Options) ->
-    ?NOT_LOADED.
-
-nif_encode_iter(_Encoder, _Stack, _IoList) ->
     ?NOT_LOADED.


### PR DESCRIPTION
Looking at scheduling and yielding noticed we had a whole bunch of dead code hanging around. Nothing calls iterator code in Erlang any longer, all our scheduling is done in C now.

On one hand it's a bit silly to keep the functions named `_init` but, on the other hand, I think it kind of makes sense, since they are still following init + iter pattern, just that the iteration continues in C.