### PR TITLE
Fixup license name to make Hex happy

### DIFF
--- a/src/jiffy.app.src
+++ b/src/jiffy.app.src
@@ -4,7 +4,7 @@
     {registered, []},
     {applications, [kernel, stdlib, xmerl]},
     {maintainers, ["Paul J. Davis", "Nick Vatamaniuc"]},
-    {licenses, ["MIT", "BSD"]},
+    {licenses, ["MIT", "BSD-3-Clause"]},
     {links, [{"GitHub", "https://github.com/davisp/jiffy"}]},
     {files, [
         "LICENSE",


### PR DESCRIPTION
Hex wants a specific BSD license type or it won't let us publish.

Conferring with Paul we decided on a 3-clause version.